### PR TITLE
Add access privacy keys to fix crash issue in iOS 10 beta 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ YMSPhotoPicker is an UIComponent that let you select mutilple photos from your a
 <img src="media/ymsphotopicker-theme.gif" alt="Square Cash Style Bar" width="300"/>
 
 #### Usage
+
+Add ```NSPhotoLibraryUsageDescription``` and ```NSCameraUsageDescription``` to your App Info.plist to specify the reason for accessing photo library and camera. See [Cocoa Keys](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html) for more details.
+
 #####Objective-C
 
 Import

--- a/YangMingShanDemo/ObjC/Info.plist
+++ b/YangMingShanDemo/ObjC/Info.plist
@@ -36,5 +36,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>The photo library is used to select photos</string>
+	<key>NSCameraUsageDescription</key>
+	<string>The camera is used to take a new photo</string>
 </dict>
 </plist>

--- a/YangMingShanDemo/Swift/Info.plist
+++ b/YangMingShanDemo/Swift/Info.plist
@@ -36,5 +36,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>The photo library is used to select photos</string>
+	<key>NSCameraUsageDescription</key>
+	<string>The camera is used to take a new photo</string>
 </dict>
 </plist>


### PR DESCRIPTION
- Update README for access reminding key explanation
- Add NSPhotoLibraryUsageDescription and NSCameraUsageDescription with reasons to access photo library and camera for both objective-C and swift demo apps
