### PR TITLE
Fix deselect crash issue

### DIFF
--- a/YangMingShan.podspec
+++ b/YangMingShan.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'YangMingShan'
   s.author       = { "Team" => "yang-ming-shan@yahoo-inc.com" }
-  s.version      = '1.2.0'
+  s.version      = '1.2.1'
   s.summary      = 'The collection of useful UI components that inspired by Yahoo apps.'
   s.homepage     = 'https://github.com/yahoo/YangMingShan'
   s.license      = "Yahoo! Inc. BSD license"

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -260,6 +260,10 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 
 - (void)collectionView:(UICollectionView *)collectionView didDeselectItemAtIndexPath:(NSIndexPath *)indexPath
 {
+    if (indexPath.item == 0) {
+        // Camera cell doesn't need to be deselected
+        return;
+    }
     PHFetchResult *fetchResult = self.currentCollectionItem[@"assets"];
     PHAsset *asset = fetchResult[indexPath.item-1];
 


### PR DESCRIPTION
Step:
1. open photo picker
2. Select first cell
3. Deny access to camera
4. Tap any photo cell
5. crash

Reason:
After select photo cell, camera cell would be deslected, however, photo picker doesn't need to deselect camera cell.

Solution:
Ignore deselect delegate if it is camera cell
