### PR TITLE
Add some options (videos handling, layout and selection ordering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ pickerViewController.configuration.sourceType = YMSPhotoPickerSourceTypeBoth;
 // Choose how to sort the picked medias.
 // YMSPhotoPickerSortingTypeSelection will display an ordered label on every selected media.
 pickerViewController.configuration.sortingType = YMSPhotoPickerSortingTypeCreationDescending;
+
+// Choose the allowed orientation
+pickerViewController.configuration.allowedOrientation = UIInterfaceOrientationMaskPortrait;
 ```
 
 With customized theme
@@ -190,6 +193,9 @@ pickerViewController.configuration.sourceType = .both
 // Choose how to sort the picked medias.
 // .selection will display an ordered label on every selected media.
 pickerViewController.configuration.sortingType = .creationDescending
+
+// Choose the allowed orientation
+pickerViewController.configuration.allowedOrientation = .portrait
 ```
 
 With customized theme

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 =====
 [![Build Status](https://travis-ci.org/yahoo/YangMingShan.svg?branch=master)](https://travis-ci.org/yahoo/YangMingShan)
 [![CocoaPods](https://img.shields.io/cocoapods/v/YangMingShan.svg?maxAge=2592000?style=flat-square)](https://cocoapods.org/?q=yangmingshan)
- 
+
 YangMingShan is a collection of iOS UI components that we created while building Yahoo apps. The reason we open source it is to share useful and common components with the community. Feel free to open the feature request ticket for new UI component you see on Yahoo apps or send pull-request to benefit open source community.
 
 Installation
@@ -21,16 +21,16 @@ The Components
 
 ### YMSPhotoPicker
 
-YMSPhotoPicker is an UIComponent that let you select mutilple photos from your albums. You can also take a photo inside YMSPhotoPicker and select it with other photos. It has the exposed theme YMSPhotoPickerTheme that you can customize several parts of YMSPhotoPicker.
+YMSPhotoPicker is an UIComponent that let you select mutilple medias (photos or videos) from your albums. You can also take a photo or a video inside YMSPhotoPicker and select it with other medias. It has the exposed theme YMSPhotoPickerTheme that you can customize several parts of YMSPhotoPicker.
 
 Part of the code in this package was derived from Yahoo Messenger and Yahoo Taiwan Auctions.
- 
+
 <img src="media/ymsphotopicker-demo.gif" alt="Square Cash Style Bar" width="300"/>
 <img src="media/ymsphotopicker-theme.gif" alt="Square Cash Style Bar" width="300"/>
 
 #### Usage
 
-Add ```NSPhotoLibraryUsageDescription``` and ```NSCameraUsageDescription``` to your App Info.plist to specify the reason for accessing photo library and camera. See [Cocoa Keys](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html) for more details.
+Add ```NSPhotoLibraryUsageDescription``` and ```NSCameraUsageDescription``` to your App Info.plist to specify the reason for accessing photo library and camera. You will also need to add ```NSMicrophoneUsageDescription``` to be able to take videos. See [Cocoa Keys](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html) for more details.
 
 #####Objective-C
 
@@ -57,6 +57,18 @@ Or init picker with limited photo selection of 10
 ```objective-c
 YMSPhotoPickerViewController *pickerViewController = [[YMSPhotoPickerViewController alloc] init];
 pickerViewController.numberOfPhotoToSelect = 10;
+```
+
+You can customize some options via the `YMSPhotoPickerConfiguration` object
+```objective-c
+// The number of thumbnails columns when browsing the medias albums.
+pickerViewController.configuration.numberOfColumns = 4;
+
+// The source type of the picker, to allow the user to only choose from their photos, their videos or both.
+pickerViewController.configuration.sourceType = YMSPhotoPickerSourceTypeBoth;
+
+// Display an ordered label on every selected media, or just a check mark.
+pickerViewController.configuration.orderedSelection = NO;
 ```
 
 With customized theme
@@ -109,13 +121,13 @@ Implement photoPickerViewControllerDidReceivePhotoAlbumAccessDenied: and photoPi
 }
 ```
 
-Implement photoPickerViewController:didFinishPickingImages: while you expect there are mutiple photo selections
+Implement photoPickerViewController:didFinishPickingMedias: while you expect there are mutiple medias selections
 
 ```objective-c
-- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingImages:(NSArray *)photoAssets
+- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingMedias:(NSArray *)assets
 {
     [picker dismissViewControllerAnimated:YES completion:^() {
-        // Remember images you get here is PHAsset array, you need to implement PHImageManager to get UIImage data by yourself
+        // Remember medias you get here is PHAsset array, you need to implement PHImageManager to get UIImage data by yourself
         PHImageManager *imageManager = [[PHImageManager alloc] init];
 
         PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
@@ -126,7 +138,7 @@ Implement photoPickerViewController:didFinishPickingImages: while you expect the
 
         NSMutableArray *mutableImages = [NSMutableArray array];
 
-        for (PHAsset *asset in photoAssets) {
+        for (PHAsset *asset in assets) {
             CGSize targetSize = CGSizeMake((CGRectGetWidth(self.collectionView.bounds) - 20*2) * [UIScreen mainScreen].scale, (CGRectGetHeight(self.collectionView.bounds) - 20*2) * [UIScreen mainScreen].scale);
             [imageManager requestImageForAsset:asset targetSize:targetSize contentMode:PHImageContentModeAspectFill options:options resultHandler:^(UIImage *image, NSDictionary *info) {
                 [mutableImages addObject:image];
@@ -166,6 +178,18 @@ let pickerViewController = YMSPhotoPickerViewController.init()
 pickerViewController.numberOfPhotoToSelect = 10
 ```
 
+You can customize some options via the `YMSPhotoPickerConfiguration` object
+```objective-c
+// The number of thumbnails columns when browsing the medias albums.
+pickerViewController.configuration.numberOfColumns = 4
+
+// The source type of the picker, to allow the user to only choose from their photos, their videos or both.
+pickerViewController.configuration.sourceType = .both
+
+// Display an ordered label on every selected media, or just a check mark.
+pickerViewController.configuration.orderedSelection = false
+```
+
 With customized theme
 
 ```swift
@@ -198,7 +222,7 @@ func photoPickerViewControllerDidReceivePhotoAlbumAccessDenied(_ picker: YMSPhot
     }
     alertController.addAction(dismissAction)
     alertController.addAction(settingsAction)
-    
+
     self.present(alertController, animated: true, completion: nil)
 }
 
@@ -210,18 +234,18 @@ func photoPickerViewControllerDidReceiveCameraAccessDenied(_ picker: YMSPhotoPic
     }
     alertController.addAction(dismissAction)
     alertController.addAction(settingsAction)
-    
+
     // The access denied of camera is always happened on picker, present alert on it to follow the view hierarchy
     picker.present(alertController, animated: true, completion: nil)
 }
 ```
 
-Implement photoPickerViewController(picker:didFinishPickingImages:) while you expect there are mutiple photo selections
+Implement photoPickerViewController(picker:didFinishPickingMedias:) while you expect there are mutiple medias selections
 
 ```swift
-func photoPickerViewController(picker: YMSPhotoPickerViewController!, didFinishPickingImages photoAssets: [PHAsset]!) {
-    // Remember images you get here is PHAsset array, you need to implement PHImageManager to get UIImage data by yourself
-    picker.dismissViewControllerAnimated(true) { 
+func photoPickerViewController(picker: YMSPhotoPickerViewController!, didFinishPickingMedias assets: [PHAsset]!) {
+    // Remember medias you get here is PHAsset array, you need to implement PHImageManager to get UIImage data by yourself
+    picker.dismissViewControllerAnimated(true) {
         let imageManager = PHImageManager.init()
         let options = PHImageRequestOptions.init()
         options.deliveryMode = .HighQualityFormat
@@ -230,7 +254,7 @@ func photoPickerViewController(picker: YMSPhotoPickerViewController!, didFinishP
 
         let mutableImages: NSMutableArray! = []
 
-        for asset: PHAsset in photoAssets
+        for asset: PHAsset in assets
         {
             let scale = UIScreen.mainScreen().scale
             let targetSize = CGSizeMake((CGRectGetWidth(self.collectionView.bounds) - 20*2) * scale, (CGRectGetHeight(self.collectionView.bounds) - 20*2) * scale)
@@ -246,12 +270,12 @@ func photoPickerViewController(picker: YMSPhotoPickerViewController!, didFinishP
 
 ### Instruction
 
-  - **Sample Codes** has been written in YangMangShanDemo project. You can read code to know about "How to implement these features in your project". Just use github to clone YangMingShan to your local disk. It should run well with your Xcode. 
+  - **Sample Codes** has been written in YangMangShanDemo project. You can read code to know about "How to implement these features in your project". Just use github to clone YangMingShan to your local disk. It should run well with your Xcode.
   - **API Reference Documents** > Please refer the [gh-pages](https://yahoo.github.io/YangMingShan/) in YangMingShan project. We use [appledoc](https://github.com/tomaz/appledoc) to generate this document. The command line we generate current document is
 ```shell
 appledoc --output {TARGET_FOLDER} --project-name "YangMingShan" --project-company "Yahoo" --company-id "com.yahoo" --no-warn-undocumented-object --keep-intermediate-files --ignore Private {YANGMINGSHAN_LOCOCAL_ROPOSITORY}
 
-```  
+```
 
 ### License
 

--- a/YangMingShan.podspec
+++ b/YangMingShan.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
   s.name         = 'YangMingShan'
-  s.author       = { "Team" => "yang-ming-shan@yahoo-inc.com" }
-  s.version      = '1.3.0'
+  s.author       = { "Team" => "yang-ming-shan@oath.com" }
+  s.version      = '2.0.0'
   s.summary      = 'The collection of useful UI components that inspired by Yahoo apps.'
   s.homepage     = 'https://github.com/yahoo/YangMingShan'
   s.license      = "Yahoo! Inc. BSD license"
   s.source       = { :git => 'https://github.com/yahoo/YangMingShan.git', :tag => s.version.to_s }
   s.requires_arc = true
   s.frameworks   = ['Foundation', 'UIKit', 'QuartzCore']
-  s.platform     = :ios, '8.0'
-  s.ios.deployment_target = '8.0'
+  s.platform     = :ios, '9.0'
+  s.ios.deployment_target = '9.0'
   s.default_subspec = 'YMSPhotoPicker'
 
   s.subspec 'YMSPhotoPicker' do |ss|

--- a/YangMingShan/YMSPhotoPicker/Private/PlayerPreviewView.h
+++ b/YangMingShan/YMSPhotoPicker/Private/PlayerPreviewView.h
@@ -1,0 +1,14 @@
+//
+//  PlayerPreviewView.h
+//  YangMingShanDemo
+//
+//  Created by Paul Ulric on 04/01/2017.
+//  Copyright © 2017 Yahoo. All rights reserved.
+//
+
+#import <AVFoundation/AVFoundation.h>
+#import <UIKit/UIKit.h>
+
+@interface PlayerPreviewView : UIView
+
+@end

--- a/YangMingShan/YMSPhotoPicker/Private/PlayerPreviewView.m
+++ b/YangMingShan/YMSPhotoPicker/Private/PlayerPreviewView.m
@@ -1,0 +1,18 @@
+//
+//  PlayerPreviewView.m
+//  YangMingShanDemo
+//
+//  Created by Paul Ulric on 04/01/2017.
+//  Copyright © 2017 Yahoo. All rights reserved.
+//
+
+#import "PlayerPreviewView.h"
+
+@implementation PlayerPreviewView
+
++ (Class)layerClass
+{
+    return [AVPlayerLayer class];
+}
+
+@end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumCell.h
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumCell.h
@@ -32,9 +32,9 @@
 @property (nonatomic, strong) NSString *albumName;
 
 /**
- * @brief Set photos count to this to display on the photos count UILabel.
+ * @brief Set medias count to this to display on the medias count UILabel.
  *
  */
-@property (nonatomic, assign) NSUInteger photosCount;
+@property (nonatomic, assign) NSUInteger mediasCount;
  
 @end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumCell.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumCell.m
@@ -13,7 +13,7 @@
 
 @property (nonatomic, weak) IBOutlet UIImageView *thumbnailImageView;
 @property (nonatomic, weak) IBOutlet UILabel *albumNameLabel;
-@property (nonatomic, weak) IBOutlet UILabel *photosCountLabel;
+@property (nonatomic, weak) IBOutlet UILabel *mediasCountLabel;
 
 @end
 
@@ -23,7 +23,7 @@
 {
     [super awakeFromNib];
 
-    self.photosCountLabel.font = [YMSPhotoPickerTheme sharedInstance].photosCountLabelFont;
+    self.mediasCountLabel.font = [YMSPhotoPickerTheme sharedInstance].mediasCountLabelFont;
     self.albumNameLabel.font = [YMSPhotoPickerTheme sharedInstance].albumNameLabelFont;
 }
 
@@ -44,15 +44,15 @@
     _albumName = albumName;
 }
 
-- (void)setPhotosCount:(NSUInteger)photosCount
+- (void)setMediasCount:(NSUInteger)mediasCount
 {
-    if (photosCount > 0) {
-        self.photosCountLabel.text = [NSString stringWithFormat:@"(%zd)", photosCount];
+    if (mediasCount > 0) {
+        self.mediasCountLabel.text = [NSString stringWithFormat:@"(%zd)", mediasCount];
     }
     else {
-        self.photosCountLabel.text = @"";
+        self.mediasCountLabel.text = @"";
     }
-    _photosCount = photosCount;    
+    _mediasCount = mediasCount;
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumCell.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumCell.xib
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -28,7 +32,7 @@
                             <constraint firstAttribute="height" constant="22" id="QQ1-WO-9RM"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" weight="light" pointSize="18"/>
-                        <color key="textColor" red="0.62352941176470589" green="0.62352941176470589" blue="0.62352941176470589" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="textColor" red="0.62352941176470589" green="0.62352941176470589" blue="0.62352941176470589" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d6s-yJ-hjZ">
@@ -37,7 +41,7 @@
                             <constraint firstAttribute="height" constant="22" id="eN7-XU-apx"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" weight="light" pointSize="18"/>
-                        <color key="textColor" red="0.24705882352941178" green="0.24705882352941178" blue="0.24705882352941178" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="textColor" red="0.24705882352941178" green="0.24705882352941178" blue="0.24705882352941178" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
@@ -60,7 +64,7 @@
             </tableViewCellContentView>
             <connections>
                 <outlet property="albumNameLabel" destination="d6s-yJ-hjZ" id="DYI-Aj-SEc"/>
-                <outlet property="photosCountLabel" destination="igR-3h-1lE" id="ZO8-5u-Dgj"/>
+                <outlet property="mediasCountLabel" destination="igR-3h-1lE" id="cbp-uX-2RN"/>
                 <outlet property="thumbnailImageView" destination="lDa-Ly-a2D" id="kTY-Al-ahg"/>
             </connections>
         </tableViewCell>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.m
@@ -16,9 +16,6 @@
 #import "YMSPhotoPickerTheme.h"
 #import "YMSPhotoPickerConfiguration.h"
 
-static const CGFloat YMSNavigationBarMaxTopSpace = 44.0;
-static const CGFloat YMSNavigationBarOriginalTopSpace = 0.0;
-
 @interface YMSAlbumPickerViewController ()<UITableViewDelegate, UITableViewDataSource>
 
 @property (nonatomic, copy) void (^dismissalHandler)(NSDictionary *);
@@ -28,7 +25,6 @@ static const CGFloat YMSNavigationBarOriginalTopSpace = 0.0;
 @property (nonatomic, weak) IBOutlet UINavigationBar *navigationBar;
 @property (nonatomic, weak) IBOutlet UIView *navigationBarBackgroundView;
 @property (nonatomic, weak) IBOutlet UITableView *albumListTableView;
-@property (nonatomic, weak) IBOutlet NSLayoutConstraint *navigationBarTopLayoutConstraint;
 @property (nonatomic, strong) UIView *footerView;
 @property (nonatomic, assign) CGFloat footerViewHeight;
 @property (nonatomic, strong) UIView *headerView;
@@ -169,57 +165,6 @@ static const CGFloat YMSNavigationBarOriginalTopSpace = 0.0;
     
     [tableView reloadData];
     [self dismiss:nil];
-}
-
-#pragma mark - UIScrollViewDelegate
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView
-{
-    // Measure table view scolling position is between the expectation
-    if (scrollView.contentOffset.y > YMSNavigationBarOriginalTopSpace
-        && scrollView.contentOffset.y + CGRectGetHeight(scrollView.bounds) < scrollView.contentSize.height - 1 - self.footerViewHeight) {
-        CGFloat topLayoutConstraintConstant = self.navigationBarTopLayoutConstraint.constant - (scrollView.contentOffset.y - scrollView.lastContentOffset.y);
-        // When next top constant is longer than maximum
-        if (topLayoutConstraintConstant < -YMSNavigationBarMaxTopSpace) {
-            self.navigationBarTopLayoutConstraint.constant = -YMSNavigationBarMaxTopSpace;
-        }
-        // When next top constant is smaller than the minimum
-        else if (topLayoutConstraintConstant > YMSNavigationBarOriginalTopSpace) {
-            self.navigationBarTopLayoutConstraint.constant = YMSNavigationBarOriginalTopSpace;
-        }
-        // Adjust navigation bar top space
-        else {
-            self.navigationBarTopLayoutConstraint.constant = topLayoutConstraintConstant;
-        }
-
-        CGFloat navigationBarAlphaStatus = 1.0 - self.navigationBarTopLayoutConstraint.constant/(YMSNavigationBarOriginalTopSpace - YMSNavigationBarMaxTopSpace);
-        self.navigationBar.alpha = navigationBarAlphaStatus;
-    }
-
-    // Measure the scroll direction for adating animation in scrollViewDidEndDragging:
-    [scrollView yms_scrollViewDidScroll];
-}
-
-- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
-{
-    // measure the end point to add animation
-    if (self.navigationBarTopLayoutConstraint.constant > -YMSNavigationBarMaxTopSpace
-        && self.navigationBarTopLayoutConstraint.constant < YMSNavigationBarOriginalTopSpace) {
-
-        [UIView animateWithDuration:0.3 animations:^{
-            if (scrollView.scrollDirection == YMSScrollViewScrollDirectionUp) {
-                self.navigationBarTopLayoutConstraint.constant = -YMSNavigationBarMaxTopSpace;
-            }
-            else if (scrollView.scrollDirection == YMSScrollViewScrollDirectionDown) {
-                self.navigationBarTopLayoutConstraint.constant = YMSNavigationBarOriginalTopSpace;
-            }
-
-            CGFloat navigationBarAlphaStatus = 1.0 - self.navigationBarTopLayoutConstraint.constant/(YMSNavigationBarOriginalTopSpace - YMSNavigationBarMaxTopSpace);
-            self.navigationBar.alpha = navigationBarAlphaStatus;
-
-            [self.view layoutIfNeeded];
-        }];
-    }
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.m
@@ -23,6 +23,7 @@
 @property (nonatomic, strong) NSArray *collectionItems;
 @property (nonatomic, strong) PHCachingImageManager *imageManager;
 @property (nonatomic, weak) IBOutlet UINavigationBar *navigationBar;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *navigationBarTopConstraint;
 @property (nonatomic, weak) IBOutlet UIView *navigationBarBackgroundView;
 @property (nonatomic, weak) IBOutlet UITableView *albumListTableView;
 @property (nonatomic, strong) UIView *footerView;
@@ -71,6 +72,8 @@
     
     [self.albumListTableView registerNib:cellNib forCellReuseIdentifier:[YMSAlbumCell yms_cellIdentifier]];
     self.footerViewHeight = CGRectGetHeight(self.view.bounds) * 2;
+    
+    [self adjustStatusBarSpace];
 }
 
 - (void)viewDidLayoutSubviews
@@ -89,6 +92,12 @@
         self.headerView.backgroundColor = [UIColor whiteColor];
         self.albumListTableView.tableHeaderView = self.headerView;
     }
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id <UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [self adjustStatusBarSpace];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle
@@ -165,6 +174,16 @@
     
     [tableView reloadData];
     [self dismiss:nil];
+}
+
+#pragma mark - Privates
+
+- (void)adjustStatusBarSpace
+{
+    if (![self.view respondsToSelector:@selector(safeAreaInsets)]) {
+        CGFloat space = UIDeviceOrientationIsLandscape(UIDevice.currentDevice.orientation) ? 0 : 20;
+        self.navigationBarTopConstraint.constant = space;
+    }
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.m
@@ -126,7 +126,7 @@ static const CGFloat YMSNavigationBarOriginalTopSpace = 0.0;
     PHCollection *collection = collectionItem[@"collection"];
     
     cell.albumName = collection.localizedTitle;
-    cell.photosCount = fetchResult.count;
+    cell.mediasCount = fetchResult.count;
     if ([collectionItem isEqual:self.selectedCollectionItem]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
     }

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.m
@@ -14,6 +14,7 @@
 #import "UITableViewCell+YMSConfig.h"
 #import "YMSAlbumCell.h"
 #import "YMSPhotoPickerTheme.h"
+#import "YMSPhotoPickerConfiguration.h"
 
 static const CGFloat YMSNavigationBarMaxTopSpace = 44.0;
 static const CGFloat YMSNavigationBarOriginalTopSpace = 0.0;
@@ -97,6 +98,11 @@ static const CGFloat YMSNavigationBarOriginalTopSpace = 0.0;
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
     return [YMSPhotoPickerTheme sharedInstance].statusBarStyle;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    return [YMSPhotoPickerConfiguration sharedInstance].allowedOrientation;
 }
 
 #pragma mark - IBActions

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -14,7 +14,6 @@
                 <outlet property="albumListTableView" destination="cLv-KU-yiY" id="zbG-0p-fUf"/>
                 <outlet property="navigationBar" destination="ACe-re-oFh" id="Rwd-mu-2aw"/>
                 <outlet property="navigationBarBackgroundView" destination="hXU-Ao-dOU" id="2Cv-8c-yVy"/>
-                <outlet property="navigationBarTopLayoutConstraint" destination="61k-oM-FiK" id="dx0-Ep-HBF"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -23,8 +22,8 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" alwaysBounceVertical="YES" style="plain" rowHeight="61" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="cLv-KU-yiY">
-                    <rect key="frame" x="0.0" y="64" width="600" height="536"/>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" rowHeight="61" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="cLv-KU-yiY">
+                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <inset key="separatorInset" minX="15" minY="0.0" maxX="15" maxY="0.0"/>
                     <connections>
@@ -32,12 +31,12 @@
                         <outlet property="delegate" destination="-1" id="8Sa-EE-XEX"/>
                     </connections>
                 </tableView>
-                <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hXU-Ao-dOU">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hXU-Ao-dOU">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
-                <navigationBar contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ACe-re-oFh">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ACe-re-oFh">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="pbv-rq-djV">
                             <variation key="heightClass=compact" constant="32"/>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSAlbumPickerViewController.xib
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,6 +15,7 @@
                 <outlet property="albumListTableView" destination="cLv-KU-yiY" id="zbG-0p-fUf"/>
                 <outlet property="navigationBar" destination="ACe-re-oFh" id="Rwd-mu-2aw"/>
                 <outlet property="navigationBarBackgroundView" destination="hXU-Ao-dOU" id="2Cv-8c-yVy"/>
+                <outlet property="navigationBarTopConstraint" destination="61k-oM-FiK" id="Zeb-1J-h75"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -36,9 +38,9 @@
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ACe-re-oFh">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                    <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="64" id="pbv-rq-djV">
+                        <constraint firstAttribute="height" constant="44" id="pbv-rq-djV">
                             <variation key="heightClass=compact" constant="32"/>
                         </constraint>
                     </constraints>
@@ -53,7 +55,7 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="hXU-Ao-dOU" firstAttribute="bottom" secondItem="ACe-re-oFh" secondAttribute="bottom" id="1sq-ne-PH6"/>
-                <constraint firstItem="ACe-re-oFh" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="61k-oM-FiK"/>
+                <constraint firstItem="ACe-re-oFh" firstAttribute="top" secondItem="8Yz-dG-1gs" secondAttribute="top" id="61k-oM-FiK"/>
                 <constraint firstAttribute="trailing" secondItem="ACe-re-oFh" secondAttribute="trailing" id="LbD-x0-voz"/>
                 <constraint firstItem="hXU-Ao-dOU" firstAttribute="leading" secondItem="ACe-re-oFh" secondAttribute="leading" id="OT5-Bz-EGP"/>
                 <constraint firstAttribute="trailing" secondItem="cLv-KU-yiY" secondAttribute="trailing" id="QgX-Ws-X4p"/>
@@ -62,9 +64,10 @@
                 <constraint firstItem="ACe-re-oFh" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="gpl-Jq-zIT"/>
                 <constraint firstItem="cLv-KU-yiY" firstAttribute="top" secondItem="ACe-re-oFh" secondAttribute="bottom" id="k9g-DN-MkA"/>
                 <constraint firstItem="cLv-KU-yiY" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="kzI-nD-sc9"/>
-                <constraint firstItem="hXU-Ao-dOU" firstAttribute="top" secondItem="ACe-re-oFh" secondAttribute="top" id="oOl-rT-72u"/>
+                <constraint firstItem="hXU-Ao-dOU" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="oOl-rT-72u"/>
                 <constraint firstAttribute="bottom" secondItem="cLv-KU-yiY" secondAttribute="bottom" id="wB7-Ia-YSG"/>
             </constraints>
+            <viewLayoutGuide key="safeArea" id="8Yz-dG-1gs"/>
             <variation key="default">
                 <mask key="constraints">
                     <exclude reference="aIU-rj-GNv"/>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.h
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.h
@@ -16,6 +16,12 @@
 @interface YMSPhotoCell : UICollectionViewCell
 
 /**
+ * @brief Set thumbnail image to this to display on cell.
+ *
+ */
+@property (nonatomic, strong) UIImage *thumbnailImage;
+
+/**
  * @brief It is the identifier for photo picker to display single photo in current album.
  *
  */

--- a/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.m
@@ -28,7 +28,6 @@ static const CGFloat YMSUnhightedAnimationSpringVelocity = 6.0;
 @property (nonatomic, assign) BOOL animateSelection;
 @property (nonatomic, assign, getter=isAnimatingHighlight) BOOL animateHighlight;
 @property (nonatomic, weak) IBOutlet UILabel *selectionOrderLabel;
-@property (nonatomic, strong) UIImage *thumbnailImage;
 
 - (void)cancelImageRequest;
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated;

--- a/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.m
@@ -90,7 +90,7 @@ static const CGFloat YMSUnhightedAnimationSpringVelocity = 6.0;
     self.imageManager = manager;
     self.imageRequestID = [self.imageManager requestImageForAsset:asset
                                                        targetSize:size
-                                                      contentMode:PHImageContentModeAspectFill
+                                                      contentMode:PHImageContentModeDefault
                                                           options:nil
                                                     resultHandler:^(UIImage *result, NSDictionary *info) {
                                                         // Set the cell's thumbnail image if it's still showing the same asset.

--- a/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.xib
@@ -25,7 +25,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.34999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="pHv-Ky-9IK">
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="pHv-Ky-9IK">
                         <rect key="frame" x="24" y="2" width="24" height="24"/>
                         <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.xib
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -12,6 +16,7 @@
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fuA-cX-VUz">
                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -21,21 +26,20 @@
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.34999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="pHv-Ky-9IK">
-                        <rect key="frame" x="24" y="24" width="24" height="24"/>
-                        <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                        <rect key="frame" x="24" y="2" width="24" height="24"/>
+                        <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="24" id="AHi-eQ-HpO"/>
                             <constraint firstAttribute="height" constant="24" id="EYa-VI-rx7"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
-                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="pHv-Ky-9IK" secondAttribute="bottom" constant="2" id="6Bf-bB-vaX"/>
+                <constraint firstAttribute="top" secondItem="pHv-Ky-9IK" secondAttribute="top" constant="-2" id="6Bf-bB-vaX"/>
                 <constraint firstAttribute="trailing" secondItem="5Nu-Tc-xoT" secondAttribute="trailing" id="7Ow-8j-oyf"/>
                 <constraint firstAttribute="bottom" secondItem="5Nu-Tc-xoT" secondAttribute="bottom" id="Ia0-V1-z0N"/>
                 <constraint firstItem="5Nu-Tc-xoT" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="LQI-8J-ihA"/>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSPlayerPreviewView.h
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSPlayerPreviewView.h
@@ -1,5 +1,5 @@
 //
-//  PlayerPreviewView.h
+//  YMSPlayerPreviewView.h
 //  YangMingShanDemo
 //
 //  Created by Paul Ulric on 04/01/2017.
@@ -9,6 +9,6 @@
 #import <AVFoundation/AVFoundation.h>
 #import <UIKit/UIKit.h>
 
-@interface PlayerPreviewView : UIView
+@interface YMSPlayerPreviewView : UIView
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSPlayerPreviewView.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSPlayerPreviewView.m
@@ -1,14 +1,14 @@
 //
-//  PlayerPreviewView.m
+//  YMSPlayerPreviewView.m
 //  YangMingShanDemo
 //
 //  Created by Paul Ulric on 04/01/2017.
 //  Copyright © 2017 Yahoo. All rights reserved.
 //
 
-#import "PlayerPreviewView.h"
+#import "YMSPlayerPreviewView.h"
 
-@implementation PlayerPreviewView
+@implementation YMSPlayerPreviewView
 
 + (Class)layerClass
 {

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaTransition.h
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaTransition.h
@@ -1,0 +1,19 @@
+//
+//  YMSSingleMediaTransition.h
+//  YangMingShanDemo
+//
+//  Created by Paul Ulric on 11/01/2017.
+//  Copyright © 2017 Yahoo. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface YMSSingleMediaTransition : NSObject<UIViewControllerAnimatedTransitioning, UIViewControllerTransitioningDelegate>
+
+@property (nonatomic, assign) BOOL isPresenting;
+@property (nonatomic, strong) UIImage *sourceImage;
+@property (nonatomic, assign) CGRect thumbnailFrame;
+@property (nonatomic, assign) CGRect detailFrame;
+
+@end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaTransition.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaTransition.m
@@ -1,0 +1,82 @@
+//
+//  YMSSingleMediaTransition.m
+//  YangMingShanDemo
+//
+//  Created by Paul Ulric on 11/01/2017.
+//  Copyright © 2017 Yahoo. All rights reserved.
+//
+
+#import "YMSSingleMediaTransition.h"
+#import "YMSSingleMediaViewController.h"
+
+
+@implementation YMSSingleMediaTransition
+
+- (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    UIView *containerView = [transitionContext containerView];
+    
+    NSTimeInterval animationDuration = [self transitionDuration:transitionContext];
+    
+    UIVisualEffectView *blurredBackgroundView = [[UIVisualEffectView alloc] initWithFrame:toViewController.view.frame];
+    [containerView addSubview:blurredBackgroundView];
+    
+    UIImageView *sourceImageView = [[UIImageView alloc] initWithImage:self.sourceImage];
+    sourceImageView.contentMode = UIViewContentModeScaleAspectFill;
+    sourceImageView.clipsToBounds = YES;
+    [containerView addSubview:sourceImageView];
+    
+    if(self.isPresenting) {
+        blurredBackgroundView.effect = nil;
+        sourceImageView.frame = self.thumbnailFrame;
+        
+        [UIView animateWithDuration:animationDuration delay:0.0 usingSpringWithDamping:0.8 initialSpringVelocity:5.0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+            sourceImageView.frame = self.detailFrame;
+            blurredBackgroundView.effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+        } completion:^(BOOL finished) {
+            [containerView addSubview:toViewController.view];
+            [sourceImageView removeFromSuperview];
+            [blurredBackgroundView removeFromSuperview];
+            
+            [transitionContext completeTransition:finished];
+        }];
+    }
+    else {
+        blurredBackgroundView.effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+        sourceImageView.frame = self.detailFrame;
+        
+        [fromViewController.view removeFromSuperview];
+        
+        [UIView animateWithDuration:animationDuration delay:0.0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+            sourceImageView.frame = self.thumbnailFrame;
+            blurredBackgroundView.effect = nil;
+        } completion:^(BOOL finished) {
+            [sourceImageView removeFromSuperview];
+            [blurredBackgroundView removeFromSuperview];
+            
+            [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+        }];
+    }
+}
+
+- (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+    return 0.3;
+}
+
+
+- (id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented presentingController:(UIViewController *)presenting sourceController:(UIViewController *)source
+{
+    self.isPresenting = YES;
+    return self;
+}
+
+- (id<UIViewControllerAnimatedTransitioning>)animationControllerForDismissedController:(UIViewController *)dismissed
+{
+    self.isPresenting = NO;
+    return self;
+}
+
+@end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaTransition.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaTransition.m
@@ -14,11 +14,11 @@
 
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
 {
+    NSTimeInterval animationDuration = [self transitionDuration:transitionContext];
+    
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     UIView *containerView = [transitionContext containerView];
-    
-    NSTimeInterval animationDuration = [self transitionDuration:transitionContext];
     
     UIVisualEffectView *blurredBackgroundView = [[UIVisualEffectView alloc] initWithFrame:toViewController.view.frame];
     [containerView addSubview:blurredBackgroundView];

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.h
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.h
@@ -1,5 +1,5 @@
 //
-//  YMSSinglePhotoViewController.h
+//  YMSSingleMediaViewController.h
 //  YangMingShan
 //
 //  Copyright 2016 Yahoo Inc.
@@ -10,18 +10,18 @@
 #import <UIKit/UIKit.h>
 
 /**
- * This is a subclass of UIViewController for displaying single photo view.
+ * This is a subclass of UIViewController for displaying single media (photo or video) view.
  */
-@interface YMSSinglePhotoViewController : UIViewController
+@interface YMSSingleMediaViewController : UIViewController
 
 /**
- * @brief Initialize YMSSinglePhotoViewController with photo asset, image manager, and dismissalHandler block.
+ * @brief Initialize YMSSingleMediaViewController with asset (photo or video), image manager, and dismissalHandler block.
  *
- * @param asset The photo asset for displaying.
+ * @param asset The asset for displaying.
  * @param manager Reuse current image manager from photo picker.
  * @param dismissalHandler The block object which is invoked before single photo view will disapear.
  */
-- (instancetype)initWithPhotoAsset:(PHAsset *)asset
+- (instancetype)initWithAsset:(PHAsset *)asset
                       imageManager:(PHImageManager *)manager
                   dismissalHandler:(void (^)(BOOL selected))dismissalHandler NS_DESIGNATED_INITIALIZER;
 

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.h
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.h
@@ -15,12 +15,6 @@
 @interface YMSSingleMediaViewController : UIViewController
 
 /**
- * @brief Describe the frame the preview will be using.
- *
- */
-@property (nonatomic, readonly) CGRect mediaPreviewFrame;
-
-/**
  * @brief Initialize YMSSingleMediaViewController with asset (photo or video), image manager, and dismissalHandler block.
  *
  * @param asset The asset for displaying.
@@ -31,5 +25,11 @@
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+
+/**
+ * @brief Compute and return the frame the preview will be using.
+ *
+ */
+- (CGRect)mediaPreviewFrame;
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.h
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.h
@@ -15,15 +15,19 @@
 @interface YMSSingleMediaViewController : UIViewController
 
 /**
+ * @brief Describe the frame the preview will be using.
+ *
+ */
+@property (nonatomic, readonly) CGRect mediaPreviewFrame;
+
+/**
  * @brief Initialize YMSSingleMediaViewController with asset (photo or video), image manager, and dismissalHandler block.
  *
  * @param asset The asset for displaying.
  * @param manager Reuse current image manager from photo picker.
- * @param dismissalHandler The block object which is invoked before single photo view will disapear.
  */
 - (instancetype)initWithAsset:(PHAsset *)asset
-                      imageManager:(PHImageManager *)manager
-                  dismissalHandler:(void (^)(BOOL selected))dismissalHandler NS_DESIGNATED_INITIALIZER;
+                      imageManager:(PHImageManager *)manager NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.m
@@ -7,7 +7,7 @@
 //
 
 #import "YMSSingleMediaViewController.h"
-#import "PlayerPreviewView.h"
+#import "YMSPlayerPreviewView.h"
 
 #import "YMSPhotoPickerTheme.h"
 
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSUInteger, PresentationStyle) {
 @property (nonatomic, weak) IBOutlet UIView *navigationBarBackgroundView;
 @property (nonatomic, weak) IBOutlet UIImageView *photoImageView;
 @property (nonatomic, weak) IBOutlet UIScrollView *imageContainerView;
-@property (weak, nonatomic) IBOutlet PlayerPreviewView *videoPreviewView;
+@property (weak, nonatomic) IBOutlet YMSPlayerPreviewView *videoPreviewView;
 @property (nonatomic, assign) PresentationStyle presentationStyle;
 
 - (IBAction)dismiss:(id)sender;

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.m
@@ -13,37 +13,22 @@
 #import "YMSPhotoPickerConfiguration.h"
 
 
-typedef NS_ENUM(NSUInteger, PresentationStyle) {
-    PresentationStyleDefault,
-    PresentationStyleDark
-};
-
 @interface YMSSingleMediaViewController ()
 
-@property (nonatomic, copy) void (^dismissalHandler)(BOOL);
 @property (nonatomic, strong) PHAsset *currentAsset;
 @property (nonatomic, weak) PHImageManager *imageManager;
-@property (nonatomic, weak) IBOutlet UINavigationBar *navigationBar;
-@property (nonatomic, weak) IBOutlet UIView *navigationBarBackgroundView;
 @property (nonatomic, weak) IBOutlet UIImageView *photoImageView;
-@property (nonatomic, weak) IBOutlet UIScrollView *imageContainerView;
 @property (weak, nonatomic) IBOutlet YMSPlayerPreviewView *videoPreviewView;
-@property (nonatomic, assign) PresentationStyle presentationStyle;
-
-- (IBAction)dismiss:(id)sender;
-- (IBAction)selectCurrentPhoto:(id)sender;
-- (IBAction)switchPresentationStyle:(id)sender;
 
 @end
 
 @implementation YMSSingleMediaViewController
 
-- (instancetype)initWithAsset:(PHAsset *)asset imageManager:(PHImageManager *)manager dismissalHandler:(void (^)(BOOL))dismissalHandler
+- (instancetype)initWithAsset:(PHAsset *)asset imageManager:(PHImageManager *)manager
 {
     self = [super initWithNibName:NSStringFromClass(self.class) bundle:[NSBundle bundleForClass:self.class]];
     if (self) {
         self.currentAsset = asset;
-        self.dismissalHandler = dismissalHandler;
         self.imageManager = manager;
     }
     return self;
@@ -51,25 +36,8 @@ typedef NS_ENUM(NSUInteger, PresentationStyle) {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view from its nib.
-
-    UINavigationItem *navigationItem = [[UINavigationItem alloc] init];
-    navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"YMSIconCancel" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil] style:UIBarButtonItemStylePlain target:self action:@selector(dismiss:)];
-    navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(selectCurrentPhoto:)];
-    self.navigationBar.items = @[navigationItem];
-
-    if (![[YMSPhotoPickerTheme sharedInstance].navigationBarBackgroundColor isEqual:[UIColor whiteColor]]) {
-        [self.navigationBar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
-        [self.navigationBar setShadowImage:[UIImage new]];
-        self.navigationBarBackgroundView.backgroundColor = [YMSPhotoPickerTheme sharedInstance].navigationBarBackgroundColor;
-    }
     
     [self loadContent];
-
-    UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(switchPresentationStyle:)];
-    [self.imageContainerView addGestureRecognizer:tapGestureRecognizer];
-
-    self.presentationStyle = PresentationStyleDefault;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle
@@ -79,10 +47,6 @@ typedef NS_ENUM(NSUInteger, PresentationStyle) {
 
 - (BOOL)prefersStatusBarHidden
 {
-    if (self.presentationStyle == PresentationStyleDefault
-        && self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular) {
-        return NO;
-    }
     return YES;
 }
 
@@ -95,19 +59,22 @@ typedef NS_ENUM(NSUInteger, PresentationStyle) {
 
 - (void)loadContent
 {
+    CGSize mediaSize = CGSizeMake(self.currentAsset.pixelWidth, self.currentAsset.pixelHeight);
+    
     if(self.currentAsset.mediaType == PHAssetMediaTypeImage) {
         [self.videoPreviewView setHidden:YES];
+        _mediaPreviewFrame = [self getFinalImageFrameForSize:mediaSize inContainer:self.photoImageView];
         
         CGFloat scale = [UIScreen mainScreen].scale;
-        CGSize imageSize = CGSizeMake(CGRectGetWidth([UIScreen mainScreen].bounds) * scale, (CGRectGetHeight([UIScreen mainScreen].bounds) - CGRectGetHeight(self.navigationBar.bounds)) * scale);
-        
+        CGSize imageSize = CGSizeMake(self.photoImageView.frame.size.width, self.photoImageView.frame.size.height);
         CGSize targetSize = CGSizeMake(imageSize.width * scale, imageSize.height * scale);
         [self.imageManager requestImageForAsset:self.currentAsset targetSize:targetSize contentMode:PHImageContentModeDefault options:nil resultHandler:^(UIImage * _Nullable result, NSDictionary * _Nullable info) {
             self.photoImageView.image = result;
         }];
     }
     else if(self.currentAsset.mediaType == PHAssetMediaTypeVideo) {
-        [self.imageContainerView setHidden:YES];
+        [self.photoImageView setHidden:YES];
+        _mediaPreviewFrame = [self getFinalImageFrameForSize:mediaSize inContainer:self.videoPreviewView];
         
         [self.imageManager requestPlayerItemForVideo:self.currentAsset options:nil resultHandler:^(AVPlayerItem * _Nullable playerItem, NSDictionary * _Nullable info) {
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -119,59 +86,19 @@ typedef NS_ENUM(NSUInteger, PresentationStyle) {
     }
 }
 
-#pragma mark - IBActions
-
-- (IBAction)dismiss:(id)sender
+- (CGRect)getFinalImageFrameForSize:(CGSize)size inContainer:(UIView*)containerView
 {
-    if (self.dismissalHandler) {
-        self.dismissalHandler(NO);
-    }
-    [self dismissViewControllerAnimated:YES completion:nil];
-}
-
-- (IBAction)selectCurrentPhoto:(id)sender
-{
-    if (self.dismissalHandler) {
-        self.dismissalHandler(YES);
-    }
-    [self dismissViewControllerAnimated:YES completion:nil];
-}
-
-- (IBAction)switchPresentationStyle:(id)sender
-{
-    if (self.presentationStyle == PresentationStyleDefault) {
-        [UIView animateWithDuration:0.15 animations:^{
-            self.view.backgroundColor = [UIColor blackColor];
-            self.navigationBar.alpha = 0.0;
-            self.navigationBarBackgroundView.alpha = 0.0;
-        } completion:^(BOOL finished) {
-            self.presentationStyle = PresentationStyleDark;
-            [self setNeedsStatusBarAppearanceUpdate];
-        }];
-    }
-    else if (self.presentationStyle == PresentationStyleDark) {
-        [UIView animateWithDuration:0.15 animations:^{
-            self.view.backgroundColor = [UIColor whiteColor];
-            self.navigationBar.alpha = 1.0;
-            self.navigationBarBackgroundView.alpha = 1.0;
-        } completion:^(BOOL finished) {
-           self.presentationStyle = PresentationStyleDefault;
-            [self setNeedsStatusBarAppearanceUpdate];
-        }];
-    }
-}
-
-#pragma mark - UIScrollViewDelegate
-
-- (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView {
-    return self.photoImageView;
-}
-
-- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view atScale:(CGFloat)scale
-{
-    if (scale <= 1.0 && self.presentationStyle == PresentationStyleDark) {
-        [self switchPresentationStyle:nil];
-    }
+    CGRect containerFrame = containerView.frame;
+    CGFloat ratioWidth = containerFrame.size.width / size.width;
+    CGFloat ratioHeight = containerFrame.size.height / size.height;
+    CGFloat ratio = MIN(ratioWidth, ratioHeight);
+    
+    CGFloat width = size.width * ratio;
+    CGFloat height = size.height * ratio;
+    CGFloat x = (containerFrame.size.width - width) / 2;
+    CGFloat y = (containerFrame.size.height - height) / 2;
+    CGRect frame = CGRectMake(x, y, width, height);
+    return [containerView convertRect:frame toView:self.view];
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.m
@@ -10,6 +10,7 @@
 #import "YMSPlayerPreviewView.h"
 
 #import "YMSPhotoPickerTheme.h"
+#import "YMSPhotoPickerConfiguration.h"
 
 
 typedef NS_ENUM(NSUInteger, PresentationStyle) {
@@ -84,6 +85,13 @@ typedef NS_ENUM(NSUInteger, PresentationStyle) {
     }
     return YES;
 }
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    return [YMSPhotoPickerConfiguration sharedInstance].allowedOrientation;
+}
+
+#pragma mark - Private Helpers
 
 - (void)loadContent
 {

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
@@ -11,9 +11,6 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YMSSingleMediaViewController">
             <connections>
-                <outlet property="imageContainerView" destination="eT2-qL-aPg" id="KI3-18-JyT"/>
-                <outlet property="navigationBar" destination="E7Z-Wo-Xkq" id="7UM-5K-cVl"/>
-                <outlet property="navigationBarBackgroundView" destination="8ns-Xd-1JA" id="zdW-13-Nid"/>
                 <outlet property="photoImageView" destination="UCj-Aa-8PT" id="b0Y-wO-qLL"/>
                 <outlet property="videoPreviewView" destination="hdm-4P-2fi" id="fd8-lM-lht"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -24,64 +21,44 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hdm-4P-2fi" customClass="YMSPlayerPreviewView">
-                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                </view>
-                <scrollView multipleTouchEnabled="YES" contentMode="scaleToFill" maximumZoomScale="2" translatesAutoresizingMaskIntoConstraints="NO" id="eT2-qL-aPg">
-                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
-                    <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="UCj-Aa-8PT">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
-                            <color key="backgroundColor" red="1" green="0.098216860201068568" blue="0.066027806799566102" alpha="0.0" colorSpace="calibratedRGB"/>
-                        </imageView>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="UCj-Aa-8PT" firstAttribute="centerY" secondItem="eT2-qL-aPg" secondAttribute="centerY" id="6jH-Xm-OcW"/>
-                        <constraint firstItem="UCj-Aa-8PT" firstAttribute="centerX" secondItem="eT2-qL-aPg" secondAttribute="centerX" id="S3H-mc-2yw"/>
-                        <constraint firstItem="UCj-Aa-8PT" firstAttribute="top" secondItem="eT2-qL-aPg" secondAttribute="top" id="XoY-rQ-jIa"/>
-                        <constraint firstItem="UCj-Aa-8PT" firstAttribute="leading" secondItem="eT2-qL-aPg" secondAttribute="leading" id="gIT-NE-vrf"/>
-                        <constraint firstAttribute="bottom" secondItem="UCj-Aa-8PT" secondAttribute="bottom" id="n4a-q7-gYp"/>
-                        <constraint firstAttribute="trailing" secondItem="UCj-Aa-8PT" secondAttribute="trailing" id="owz-Yd-agF"/>
-                    </constraints>
-                    <connections>
-                        <outlet property="delegate" destination="-1" id="cGl-dV-dqm"/>
-                    </connections>
-                </scrollView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ns-Xd-1JA">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
-                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                </view>
-                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E7Z-Wo-Xkq">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="64" id="Udo-Dl-J0F">
-                            <variation key="heightClass=compact" constant="32"/>
-                        </constraint>
-                    </constraints>
-                    <items>
-                        <navigationItem id="QSQ-6O-8Rn"/>
-                    </items>
-                </navigationBar>
+                <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JlU-u3-gc1">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="9GQ-Np-1as">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hdm-4P-2fi" customClass="YMSPlayerPreviewView">
+                                <rect key="frame" x="20" y="60" width="335" height="547"/>
+                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </view>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="UCj-Aa-8PT">
+                                <rect key="frame" x="20" y="60" width="335" height="547"/>
+                                <color key="backgroundColor" red="1" green="0.098216860201068568" blue="0.066027806799566102" alpha="0.0" colorSpace="calibratedRGB"/>
+                            </imageView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="UCj-Aa-8PT" firstAttribute="top" secondItem="9GQ-Np-1as" secondAttribute="top" constant="60" id="0OG-gD-cjh"/>
+                            <constraint firstAttribute="trailing" secondItem="UCj-Aa-8PT" secondAttribute="trailing" constant="20" id="0PW-eb-7gs"/>
+                            <constraint firstItem="hdm-4P-2fi" firstAttribute="leading" secondItem="9GQ-Np-1as" secondAttribute="leading" constant="20" id="UEu-Bi-vbL"/>
+                            <constraint firstItem="hdm-4P-2fi" firstAttribute="top" secondItem="9GQ-Np-1as" secondAttribute="top" constant="60" id="V5S-Lv-LWe"/>
+                            <constraint firstItem="UCj-Aa-8PT" firstAttribute="leading" secondItem="9GQ-Np-1as" secondAttribute="leading" constant="20" id="eQr-1B-raT"/>
+                            <constraint firstAttribute="bottom" secondItem="hdm-4P-2fi" secondAttribute="bottom" constant="60" id="je3-6l-IZd"/>
+                            <constraint firstAttribute="bottom" secondItem="UCj-Aa-8PT" secondAttribute="bottom" constant="60" id="mRu-yu-JcX"/>
+                            <constraint firstAttribute="trailing" secondItem="hdm-4P-2fi" secondAttribute="trailing" constant="20" id="pKd-4B-yN1"/>
+                        </constraints>
+                    </view>
+                    <blurEffect style="dark"/>
+                </visualEffectView>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="8ns-Xd-1JA" firstAttribute="top" secondItem="E7Z-Wo-Xkq" secondAttribute="top" id="1GY-gn-bVp"/>
-                <constraint firstItem="E7Z-Wo-Xkq" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="4pX-5U-QPG"/>
-                <constraint firstAttribute="trailing" secondItem="E7Z-Wo-Xkq" secondAttribute="trailing" id="8mx-0o-oVN"/>
-                <constraint firstAttribute="bottom" secondItem="hdm-4P-2fi" secondAttribute="bottom" id="Ffw-4w-E6z"/>
-                <constraint firstItem="8ns-Xd-1JA" firstAttribute="leading" secondItem="E7Z-Wo-Xkq" secondAttribute="leading" id="ICR-r3-VNr"/>
-                <constraint firstItem="hdm-4P-2fi" firstAttribute="top" secondItem="E7Z-Wo-Xkq" secondAttribute="bottom" id="K7l-Ek-wRW"/>
-                <constraint firstItem="hdm-4P-2fi" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="P8e-7n-bvQ"/>
-                <constraint firstItem="eT2-qL-aPg" firstAttribute="top" secondItem="E7Z-Wo-Xkq" secondAttribute="bottom" id="Rhc-25-16K"/>
-                <constraint firstAttribute="trailing" secondItem="hdm-4P-2fi" secondAttribute="trailing" id="VLs-bt-Rmv"/>
-                <constraint firstItem="8ns-Xd-1JA" firstAttribute="trailing" secondItem="E7Z-Wo-Xkq" secondAttribute="trailing" id="YY4-lh-3uB"/>
-                <constraint firstAttribute="trailing" secondItem="eT2-qL-aPg" secondAttribute="trailing" id="mAe-0S-h8m"/>
-                <constraint firstItem="eT2-qL-aPg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="nOf-tD-Xu8"/>
-                <constraint firstItem="8ns-Xd-1JA" firstAttribute="bottom" secondItem="E7Z-Wo-Xkq" secondAttribute="bottom" id="poi-XS-uU0"/>
-                <constraint firstItem="E7Z-Wo-Xkq" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="rTW-SY-I5h"/>
-                <constraint firstAttribute="bottom" secondItem="eT2-qL-aPg" secondAttribute="bottom" id="yUL-dS-p46"/>
+                <constraint firstAttribute="bottom" secondItem="JlU-u3-gc1" secondAttribute="bottom" id="A7Z-N5-doz"/>
+                <constraint firstAttribute="trailing" secondItem="JlU-u3-gc1" secondAttribute="trailing" id="Hzc-HU-vOn"/>
+                <constraint firstItem="JlU-u3-gc1" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="e6o-A0-DDw"/>
+                <constraint firstItem="JlU-u3-gc1" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="k0g-vv-hB9"/>
             </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <point key="canvasLocation" x="-346" y="40"/>
         </view>
     </objects>
 </document>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
@@ -24,7 +24,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hdm-4P-2fi" customClass="PlayerPreviewView">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hdm-4P-2fi" customClass="YMSPlayerPreviewView">
                     <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 </view>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
@@ -11,6 +11,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YMSSingleMediaViewController">
             <connections>
+                <outlet property="containerLeftConstraint" destination="ixv-Ps-rde" id="yvj-jr-56W"/>
+                <outlet property="containerTopConstraint" destination="OoQ-x8-YvI" id="H9K-v9-Yrz"/>
                 <outlet property="photoImageView" destination="UCj-Aa-8PT" id="b0Y-wO-qLL"/>
                 <outlet property="videoPreviewView" destination="hdm-4P-2fi" id="fd8-lM-lht"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -27,24 +29,35 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hdm-4P-2fi" customClass="YMSPlayerPreviewView">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GMH-kN-CqQ">
                                 <rect key="frame" x="20" y="60" width="335" height="547"/>
-                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hdm-4P-2fi" customClass="YMSPlayerPreviewView">
+                                        <rect key="frame" x="0.0" y="0.0" width="335" height="547"/>
+                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
+                                    </view>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="UCj-Aa-8PT">
+                                        <rect key="frame" x="0.0" y="0.0" width="335" height="547"/>
+                                        <color key="backgroundColor" red="1" green="0.098216860201068568" blue="0.066027806799566102" alpha="0.0" colorSpace="calibratedRGB"/>
+                                    </imageView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="hdm-4P-2fi" secondAttribute="bottom" id="6cp-nv-FTT"/>
+                                    <constraint firstItem="hdm-4P-2fi" firstAttribute="top" secondItem="GMH-kN-CqQ" secondAttribute="top" id="FCh-5o-fRh"/>
+                                    <constraint firstItem="UCj-Aa-8PT" firstAttribute="leading" secondItem="GMH-kN-CqQ" secondAttribute="leading" id="KOX-gX-P27"/>
+                                    <constraint firstAttribute="bottom" secondItem="UCj-Aa-8PT" secondAttribute="bottom" id="Nrc-N3-rar"/>
+                                    <constraint firstItem="UCj-Aa-8PT" firstAttribute="top" secondItem="GMH-kN-CqQ" secondAttribute="top" id="OfH-CJ-4Yp"/>
+                                    <constraint firstAttribute="trailing" secondItem="UCj-Aa-8PT" secondAttribute="trailing" id="To3-bf-0tu"/>
+                                    <constraint firstItem="hdm-4P-2fi" firstAttribute="leading" secondItem="GMH-kN-CqQ" secondAttribute="leading" id="dXm-oe-y5I"/>
+                                    <constraint firstAttribute="trailing" secondItem="hdm-4P-2fi" secondAttribute="trailing" id="t7E-tN-s3f"/>
+                                </constraints>
                             </view>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="UCj-Aa-8PT">
-                                <rect key="frame" x="20" y="60" width="335" height="547"/>
-                                <color key="backgroundColor" red="1" green="0.098216860201068568" blue="0.066027806799566102" alpha="0.0" colorSpace="calibratedRGB"/>
-                            </imageView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="UCj-Aa-8PT" firstAttribute="top" secondItem="9GQ-Np-1as" secondAttribute="top" constant="60" id="0OG-gD-cjh"/>
-                            <constraint firstAttribute="trailing" secondItem="UCj-Aa-8PT" secondAttribute="trailing" constant="20" id="0PW-eb-7gs"/>
-                            <constraint firstItem="hdm-4P-2fi" firstAttribute="leading" secondItem="9GQ-Np-1as" secondAttribute="leading" constant="20" id="UEu-Bi-vbL"/>
-                            <constraint firstItem="hdm-4P-2fi" firstAttribute="top" secondItem="9GQ-Np-1as" secondAttribute="top" constant="60" id="V5S-Lv-LWe"/>
-                            <constraint firstItem="UCj-Aa-8PT" firstAttribute="leading" secondItem="9GQ-Np-1as" secondAttribute="leading" constant="20" id="eQr-1B-raT"/>
-                            <constraint firstAttribute="bottom" secondItem="hdm-4P-2fi" secondAttribute="bottom" constant="60" id="je3-6l-IZd"/>
-                            <constraint firstAttribute="bottom" secondItem="UCj-Aa-8PT" secondAttribute="bottom" constant="60" id="mRu-yu-JcX"/>
-                            <constraint firstAttribute="trailing" secondItem="hdm-4P-2fi" secondAttribute="trailing" constant="20" id="pKd-4B-yN1"/>
+                            <constraint firstAttribute="trailing" secondItem="GMH-kN-CqQ" secondAttribute="trailing" constant="20" id="0QU-Nz-fJ2"/>
+                            <constraint firstItem="GMH-kN-CqQ" firstAttribute="top" secondItem="9GQ-Np-1as" secondAttribute="top" constant="60" id="OoQ-x8-YvI"/>
+                            <constraint firstAttribute="bottom" secondItem="GMH-kN-CqQ" secondAttribute="bottom" constant="60" id="UUx-Sx-rOZ"/>
+                            <constraint firstItem="GMH-kN-CqQ" firstAttribute="leading" secondItem="9GQ-Np-1as" secondAttribute="leading" constant="20" id="ixv-Ps-rde"/>
                         </constraints>
                     </view>
                     <blurEffect style="dark"/>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -71,6 +72,7 @@
                 <constraint firstItem="JlU-u3-gc1" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="k0g-vv-hB9"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
+            <viewLayoutGuide key="safeArea" id="n0Z-nE-Six"/>
             <point key="canvasLocation" x="-346" y="40"/>
         </view>
     </objects>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib
@@ -1,29 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YMSSinglePhotoViewController">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YMSSingleMediaViewController">
             <connections>
                 <outlet property="imageContainerView" destination="eT2-qL-aPg" id="KI3-18-JyT"/>
                 <outlet property="navigationBar" destination="E7Z-Wo-Xkq" id="7UM-5K-cVl"/>
                 <outlet property="navigationBarBackgroundView" destination="8ns-Xd-1JA" id="zdW-13-Nid"/>
                 <outlet property="photoImageView" destination="UCj-Aa-8PT" id="b0Y-wO-qLL"/>
+                <outlet property="videoPreviewView" destination="hdm-4P-2fi" id="fd8-lM-lht"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hdm-4P-2fi" customClass="PlayerPreviewView">
+                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                </view>
                 <scrollView multipleTouchEnabled="YES" contentMode="scaleToFill" maximumZoomScale="2" translatesAutoresizingMaskIntoConstraints="NO" id="eT2-qL-aPg">
-                    <rect key="frame" x="0.0" y="64" width="600" height="536"/>
+                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="UCj-Aa-8PT">
-                            <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                            <color key="backgroundColor" red="1" green="0.098216860201068568" blue="0.066027806799566102" alpha="0.0" colorSpace="calibratedRGB"/>
                         </imageView>
                     </subviews>
                     <constraints>
@@ -39,11 +49,11 @@
                     </connections>
                 </scrollView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ns-Xd-1JA">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E7Z-Wo-Xkq">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="Udo-Dl-J0F">
                             <variation key="heightClass=compact" constant="32"/>
@@ -54,13 +64,17 @@
                     </items>
                 </navigationBar>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="8ns-Xd-1JA" firstAttribute="top" secondItem="E7Z-Wo-Xkq" secondAttribute="top" id="1GY-gn-bVp"/>
                 <constraint firstItem="E7Z-Wo-Xkq" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="4pX-5U-QPG"/>
                 <constraint firstAttribute="trailing" secondItem="E7Z-Wo-Xkq" secondAttribute="trailing" id="8mx-0o-oVN"/>
+                <constraint firstAttribute="bottom" secondItem="hdm-4P-2fi" secondAttribute="bottom" id="Ffw-4w-E6z"/>
                 <constraint firstItem="8ns-Xd-1JA" firstAttribute="leading" secondItem="E7Z-Wo-Xkq" secondAttribute="leading" id="ICR-r3-VNr"/>
+                <constraint firstItem="hdm-4P-2fi" firstAttribute="top" secondItem="E7Z-Wo-Xkq" secondAttribute="bottom" id="K7l-Ek-wRW"/>
+                <constraint firstItem="hdm-4P-2fi" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="P8e-7n-bvQ"/>
                 <constraint firstItem="eT2-qL-aPg" firstAttribute="top" secondItem="E7Z-Wo-Xkq" secondAttribute="bottom" id="Rhc-25-16K"/>
+                <constraint firstAttribute="trailing" secondItem="hdm-4P-2fi" secondAttribute="trailing" id="VLs-bt-Rmv"/>
                 <constraint firstItem="8ns-Xd-1JA" firstAttribute="trailing" secondItem="E7Z-Wo-Xkq" secondAttribute="trailing" id="YY4-lh-3uB"/>
                 <constraint firstAttribute="trailing" secondItem="eT2-qL-aPg" secondAttribute="trailing" id="mAe-0S-h8m"/>
                 <constraint firstItem="eT2-qL-aPg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="nOf-tD-Xu8"/>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSVideoCell.h
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSVideoCell.h
@@ -1,0 +1,13 @@
+//
+//  YMSVideoCell.h
+//  YangMingShanDemo
+//
+//  Created by Paul Ulric on 03/01/2017.
+//  Copyright © 2017 Yahoo. All rights reserved.
+//
+
+#import "YMSPhotoCell.h"
+
+@interface YMSVideoCell : YMSPhotoCell
+
+@end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSVideoCell.m
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSVideoCell.m
@@ -1,0 +1,55 @@
+//
+//  YMSVideoCell.m
+//  YangMingShanDemo
+//
+//  Created by Paul Ulric on 03/01/2017.
+//  Copyright © 2017 Yahoo. All rights reserved.
+//
+
+#import "YMSVideoCell.h"
+
+@interface YMSVideoCell()
+
+@property (nonatomic, weak) IBOutlet UIView *videoOverlay;
+@property (nonatomic, weak) IBOutlet UILabel *videoDuration;
+
+@end
+
+@implementation YMSVideoCell
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    
+    CAGradientLayer *gradientLayer = [self createDurationOverlay];
+    [self.videoOverlay.layer insertSublayer:gradientLayer atIndex:0];
+}
+
+#pragma mark - Publics
+
+- (void)loadPhotoWithManager:(PHImageManager *)manager forAsset:(PHAsset *)asset targetSize:(CGSize)size
+{
+    [super loadPhotoWithManager:manager forAsset:asset targetSize:size];
+    
+    int duration = (int)asset.duration;
+    int minutes = duration / 60;
+    int seconds = duration % 60;
+    self.videoDuration.text = [NSString stringWithFormat:@"%i:%02i", minutes, seconds];
+}
+
+#pragma mark - Privates
+
+- (CAGradientLayer*)createDurationOverlay
+{
+    UIColor *darkColor = [UIColor colorWithWhite:0 alpha:0.5];
+    UIColor *lightColor = [UIColor clearColor];
+    
+    CAGradientLayer *gradientLayer = [CAGradientLayer layer];
+    gradientLayer.frame = self.videoOverlay.bounds;
+    gradientLayer.colors = @[(id)lightColor.CGColor, (id)darkColor.CGColor];
+    gradientLayer.locations = @[@(0.2), @(1.0)];
+    return gradientLayer;
+}
+
+
+@end

--- a/YangMingShan/YMSPhotoPicker/Private/YMSVideoCell.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSVideoCell.xib
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="YMSVideoCell" id="tls-st-B4v" customClass="YMSVideoCell">
+            <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hM3-UB-VKw">
+                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                    </imageView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AVx-6D-ys4">
+                        <rect key="frame" x="0.0" y="75" width="100" height="25"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rlL-yv-Wrr">
+                                <rect key="frame" x="67.5" y="5.5" width="26.5" height="14.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="0.80474137931034484" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="rlL-yv-Wrr" secondAttribute="trailing" constant="6" id="RLZ-uu-DSc"/>
+                            <constraint firstAttribute="height" constant="25" id="bLi-PA-Yaa"/>
+                            <constraint firstItem="rlL-yv-Wrr" firstAttribute="centerY" secondItem="AVx-6D-ys4" secondAttribute="centerY" id="jk7-1O-p5B"/>
+                        </constraints>
+                    </view>
+                    <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rs5-zv-zYQ" userLabel="Selection Veil">
+                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.34999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000001192092896" translatesAutoresizingMaskIntoConstraints="NO" id="7HL-xz-YQF">
+                        <rect key="frame" x="74" y="2" width="24" height="24"/>
+                        <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="24" id="Yau-0A-1pE"/>
+                            <constraint firstAttribute="height" constant="24" id="ava-Ll-Dcm"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </view>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="7HL-xz-YQF" secondAttribute="trailing" constant="2" id="4Ao-hh-su9"/>
+                <constraint firstItem="Rs5-zv-zYQ" firstAttribute="leading" secondItem="tls-st-B4v" secondAttribute="leading" id="9Ff-hP-vLU"/>
+                <constraint firstItem="hM3-UB-VKw" firstAttribute="leading" secondItem="tls-st-B4v" secondAttribute="leading" id="BDu-nT-eNP"/>
+                <constraint firstItem="AVx-6D-ys4" firstAttribute="leading" secondItem="tls-st-B4v" secondAttribute="leading" id="DDb-gM-KSn"/>
+                <constraint firstAttribute="bottom" secondItem="Rs5-zv-zYQ" secondAttribute="bottom" id="De2-Pz-gaa"/>
+                <constraint firstAttribute="trailing" secondItem="AVx-6D-ys4" secondAttribute="trailing" id="Ic9-2a-mOu"/>
+                <constraint firstItem="Rs5-zv-zYQ" firstAttribute="top" secondItem="tls-st-B4v" secondAttribute="top" id="KAK-q6-V5Z"/>
+                <constraint firstAttribute="trailing" secondItem="hM3-UB-VKw" secondAttribute="trailing" id="QVT-rD-JaI"/>
+                <constraint firstAttribute="trailing" secondItem="Rs5-zv-zYQ" secondAttribute="trailing" id="XXH-qE-zrv"/>
+                <constraint firstAttribute="bottom" secondItem="AVx-6D-ys4" secondAttribute="bottom" id="ZxX-fv-dKC"/>
+                <constraint firstItem="hM3-UB-VKw" firstAttribute="top" secondItem="tls-st-B4v" secondAttribute="top" id="kEs-Vs-uHF"/>
+                <constraint firstAttribute="top" secondItem="7HL-xz-YQF" secondAttribute="top" constant="-2" id="kun-8v-RCI"/>
+                <constraint firstAttribute="bottom" secondItem="hM3-UB-VKw" secondAttribute="bottom" id="zAh-5s-LZQ"/>
+            </constraints>
+            <size key="customSize" width="105" height="100"/>
+            <connections>
+                <outlet property="imageView" destination="hM3-UB-VKw" id="Zqs-LL-KNc"/>
+                <outlet property="selectionOrderLabel" destination="7HL-xz-YQF" id="t6g-jB-ngG"/>
+                <outlet property="selectionVeil" destination="Rs5-zv-zYQ" id="aJN-y5-mos"/>
+                <outlet property="videoDuration" destination="rlL-yv-Wrr" id="9YT-hb-GyA"/>
+                <outlet property="videoOverlay" destination="AVx-6D-ys4" id="waB-S5-czQ"/>
+            </connections>
+            <point key="canvasLocation" x="43" y="0.0"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/YangMingShan/YMSPhotoPicker/Private/YMSVideoCell.xib
+++ b/YangMingShan/YMSPhotoPicker/Private/YMSVideoCell.xib
@@ -42,7 +42,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.34999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000001192092896" translatesAutoresizingMaskIntoConstraints="NO" id="7HL-xz-YQF">
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000001192092896" translatesAutoresizingMaskIntoConstraints="NO" id="7HL-xz-YQF">
                         <rect key="frame" x="74" y="2" width="24" height="24"/>
                         <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>

--- a/YangMingShan/YMSPhotoPicker/Public/UIViewController+YMSPhotoHelper.m
+++ b/YangMingShan/YMSPhotoPicker/Public/UIViewController+YMSPhotoHelper.m
@@ -22,6 +22,11 @@
             UIImagePickerController *imagePickerController = [[UIImagePickerController alloc] init];
             imagePickerController.delegate = delegate;
             imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
+            if ([delegate isKindOfClass:[YMSPhotoPickerViewController class]]) {
+                YMSPhotoPickerViewController *pickerViewController = (YMSPhotoPickerViewController *)delegate;
+                YMSPhotoPickerSourceType sourceType = pickerViewController.configuration.sourceType;
+                imagePickerController.mediaTypes = [self mediaTypesForConfigurationSourceType:sourceType];
+            }
             [self presentViewController:imagePickerController animated:YES completion:nil];
         }
         else if(status == AVAuthorizationStatusDenied
@@ -97,6 +102,21 @@
     else {
         // Cannot recognize current status. Do nothing here.
     }
+}
+
+
+#pragma mark - Privates
+
+- (NSArray*) mediaTypesForConfigurationSourceType:(YMSPhotoPickerSourceType)sourceType
+{
+    NSMutableArray *mediaTypes = [NSMutableArray new];
+    if(sourceType == YMSPhotoPickerSourceTypePhoto || sourceType == YMSPhotoPickerSourceTypeBoth) {
+        [mediaTypes addObject:(NSString*)kUTTypeImage];
+    }
+    if(sourceType == YMSPhotoPickerSourceTypeVideo || sourceType == YMSPhotoPickerSourceTypeBoth) {
+        [mediaTypes addObject:(NSString*)kUTTypeMovie];
+    }
+    return mediaTypes;
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Public/UIViewController+YMSPhotoHelper.m
+++ b/YangMingShan/YMSPhotoPicker/Public/UIViewController+YMSPhotoHelper.m
@@ -45,6 +45,11 @@
                         UIImagePickerController *imagePickerController = [[UIImagePickerController alloc] init];
                         imagePickerController.delegate = delegate;
                         imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
+                        if ([delegate isKindOfClass:[YMSPhotoPickerViewController class]]) {
+                            YMSPhotoPickerViewController *pickerViewController = (YMSPhotoPickerViewController *)delegate;
+                            YMSPhotoPickerSourceType sourceType = pickerViewController.configuration.sourceType;
+                            imagePickerController.mediaTypes = [self mediaTypesForConfigurationSourceType:sourceType];
+                        }
                         [self presentViewController:imagePickerController animated:YES completion:nil];
                     }
                     else {

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
@@ -9,6 +9,16 @@
 #import <Foundation/Foundation.h>
 
 /**
+ * These are the available source types the photo picker will allow the user to select.
+ */
+typedef NS_ENUM(NSUInteger, YMSPhotoPickerSourceType) {
+    YMSPhotoPickerSourceTypePhoto,
+    YMSPhotoPickerSourceTypeVideo,
+    YMSPhotoPickerSourceTypeBoth
+};
+
+
+/**
  * This is the centralized configuration for photo picker. This is a singleton class, so remember use sharedInstance to access it instead of init method.
  *
  */
@@ -19,6 +29,12 @@
  *
  */
 @property (nonatomic, assign) NSUInteger numberOfColumns;
+
+/**
+ * @brief Describe the type of medias that the user will be allowed to choose from.
+ *
+ */
+@property (nonatomic, assign) YMSPhotoPickerSourceType sourceType;
 
 /**
  * @brief Getting a shared instance of YMSPhotoPickerConfiguration.

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
@@ -1,0 +1,36 @@
+//
+//  YMSPhotoPickerConfiguration.h
+//  YangMingShanDemo
+//
+//  Created by Paul Ulric on 03/01/2017.
+//  Copyright © 2017 Yahoo. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ * This is the centralized configuration for photo picker. This is a singleton class, so remember use sharedInstance to access it instead of init method.
+ *
+ */
+@interface YMSPhotoPickerConfiguration : NSObject
+
+/**
+ * @brief Describe the number of thumbnails columns displayed while browsing the library, and therefore the number of thumbnails visible at once.
+ *
+ */
+@property (nonatomic, assign) NSUInteger numberOfColumns;
+
+/**
+ * @brief Getting a shared instance of YMSPhotoPickerConfiguration.
+ *
+ * @return Instance of YMSPhotoPickerConfiguration.
+ */
++ (instancetype)sharedInstance;
+
+/**
+ * @brief Reset configuration to default.
+ *
+ */
+- (void)reset;
+
+@end

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
@@ -1,6 +1,6 @@
 //
 //  YMSPhotoPickerConfiguration.h
-//  YangMingShanDemo
+//  YangMingShan
 //
 //  Created by Paul Ulric on 03/01/2017.
 //  Copyright © 2017 Yahoo. All rights reserved.

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
@@ -37,6 +37,12 @@ typedef NS_ENUM(NSUInteger, YMSPhotoPickerSourceType) {
 @property (nonatomic, assign) YMSPhotoPickerSourceType sourceType;
 
 /**
+ * @brief Describe if the cells should be selected in an ordered way (displaying the picking order).
+ *
+ */
+@property (nonatomic, assign) BOOL orderedSelection;
+
+/**
  * @brief Getting a shared instance of YMSPhotoPickerConfiguration.
  *
  * @return Instance of YMSPhotoPickerConfiguration.

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.h
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Yahoo. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 /**
  * These are the available source types the photo picker will allow the user to select.
@@ -50,6 +50,12 @@ typedef NS_ENUM(NSUInteger, YMSPhotoPickerSortingType) {
  *
  */
 @property (nonatomic, assign) YMSPhotoPickerSortingType sortingType;
+
+/**
+ * @brief Describe the orientations allowed.
+ *
+ */
+@property (nonatomic, assign) UIInterfaceOrientationMask allowedOrientation;
 
 /**
  * @brief Getting a shared instance of YMSPhotoPickerConfiguration.

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
@@ -1,0 +1,30 @@
+//
+//  YMSPhotoPickerConfiguration.m
+//  YangMingShanDemo
+//
+//  Created by Paul Ulric on 03/01/2017.
+//  Copyright © 2017 Yahoo. All rights reserved.
+//
+
+#import "YMSPhotoPickerConfiguration.h"
+
+@implementation YMSPhotoPickerConfiguration
+
++ (instancetype)sharedInstance
+{
+    static YMSPhotoPickerConfiguration *instance;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        instance = [[YMSPhotoPickerConfiguration alloc] init];
+        [instance reset];
+    });
+    return instance;
+}
+
+- (void)reset
+{
+    self.numberOfColumns = 3;
+}
+
+@end

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
@@ -27,6 +27,7 @@
     self.numberOfColumns = 3;
     self.sourceType = YMSPhotoPickerSourceTypePhoto;
     self.sortingType = YMSPhotoPickerSortingTypeSelection;
+    self.allowedOrientation = UIInterfaceOrientationMaskAll;
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
@@ -26,6 +26,7 @@
 {
     self.numberOfColumns = 3;
     self.sourceType = YMSPhotoPickerSourceTypePhoto;
+    self.orderedSelection = YES;
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
@@ -25,6 +25,7 @@
 - (void)reset
 {
     self.numberOfColumns = 3;
+    self.sourceType = YMSPhotoPickerSourceTypePhoto;
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerConfiguration.m
@@ -1,6 +1,6 @@
 //
 //  YMSPhotoPickerConfiguration.m
-//  YangMingShanDemo
+//  YangMingShan
 //
 //  Created by Paul Ulric on 03/01/2017.
 //  Copyright © 2017 Yahoo. All rights reserved.

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerTheme.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerTheme.h
@@ -79,7 +79,7 @@
  * @brief Describe a specify UIFont that you want to apply to the table view showing photo count insdie album.
  *
  */
-@property (nonatomic, strong) UIFont *photosCountLabelFont;
+@property (nonatomic, strong) UIFont *mediasCountLabelFont;
 
 /**
  * @brief Describe a specify UIFont that you want to apply to the number in the bottom right of photo cells after they're selected, denoting order of selection.

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerTheme.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerTheme.m
@@ -43,7 +43,7 @@
     self.statusBarStyle = UIStatusBarStyleDefault;
     self.titleLabelFont = [UIFont systemFontOfSize:18.0];
     self.albumNameLabelFont = [UIFont systemFontOfSize:18.0 weight:UIFontWeightLight];
-    self.photosCountLabelFont = [UIFont systemFontOfSize:18.0 weight:UIFontWeightLight];
+    self.mediasCountLabelFont = [UIFont systemFontOfSize:18.0 weight:UIFontWeightLight];
     self.selectionOrderLabelFont = [UIFont systemFontOfSize:17.0];
 }
 

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.h
@@ -10,6 +10,7 @@
 #import <UIKit/UIKit.h>
 
 #import "YMSPhotoPickerTheme.h"
+#import "YMSPhotoPickerConfiguration.h"
 
 @protocol YMSPhotoPickerViewControllerDelegate;
 
@@ -41,6 +42,9 @@
  *  @brief Use this property to customize the returned item type for single selection. YES for UIImage, NO for PHAsset. Default value is YES.
  */
 @property (nonatomic, assign) BOOL shouldReturnImageForSingleSelection;
+
+
+@property (nonatomic, readonly) YMSPhotoPickerConfiguration* configuration;
 
 @end
 

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.h
@@ -33,7 +33,7 @@
 @property (nonatomic, assign) NSUInteger numberOfPhotoToSelect;
 
 /**
- * @brief Use YMSPhotoPickerTheme to customize the UI appearance for YMSPhotoPickerViewController, YMSSinglePhotoViewController, and YMSAlbumPickerViewController. See YMSPhotoPickerTheme.h for more details.
+ * @brief Use YMSPhotoPickerTheme to customize the UI appearance for YMSPhotoPickerViewController, YMSSingleMediaViewController, and YMSAlbumPickerViewController. See YMSPhotoPickerTheme.h for more details.
  *
  */
 @property (nonatomic, readonly) YMSPhotoPickerTheme *theme;

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.h
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.h
@@ -8,6 +8,7 @@
 
 #import <Photos/Photos.h>
 #import <UIKit/UIKit.h>
+#import <MobileCoreServices/MobileCoreServices.h>
 
 #import "YMSPhotoPickerTheme.h"
 #import "YMSPhotoPickerConfiguration.h"
@@ -27,10 +28,10 @@
 @property (nonatomic, weak) id<YMSPhotoPickerViewControllerDelegate> delegate;
 
 /**
- * @brief Set numberOfPhotoToSelect to limit maximum number of photo selections. Default value is 1 and you can set it to 0 for unlimited selections.
+ * @brief Set numberOfMediaToSelect to limit maximum number of media selections. Default value is 1 and you can set it to 0 for unlimited selections.
  *
  */
-@property (nonatomic, assign) NSUInteger numberOfPhotoToSelect;
+@property (nonatomic, assign) NSUInteger numberOfMediaToSelect;
 
 /**
  * @brief Use YMSPhotoPickerTheme to customize the UI appearance for YMSPhotoPickerViewController, YMSSingleMediaViewController, and YMSAlbumPickerViewController. See YMSPhotoPickerTheme.h for more details.
@@ -71,20 +72,20 @@
 
 @optional
 /**
- * @brief Invoked when view controller finish picking single image from camera or photo album. The picker does not dismiss itself; the client dismisses it in this callback.
+ * @brief Invoked when view controller finish picking single media from camera or photo album. The picker does not dismiss itself; the client dismisses it in this callback.
  *
  * @param picker The view controller invoking the delegate method.
- * @param image The UIImage object user picked.
+ * @param asset The PHAsset object user picked.
  */
-- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingImage:(UIImage *)image;
+- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingMedia:(PHAsset *)asset;
 
 /**
- * @brief Invoked when user press done button with greater than or equal to one image(s) from camera or photo album. The picker does not dismiss itself; the client dismisses it in this callback.
+ * @brief Invoked when user press done button with greater than or equal to one media(s) from camera or photo album. The picker does not dismiss itself; the client dismisses it in this callback.
  *
  * @param picker The view controller invoking the delegate method.
- * @param photoAssets The NSArray object contains PHAsset object(s) user picked.
+ * @param assets The NSArray object contains PHAsset object(s) user picked.
  */
-- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingImages:(NSArray<PHAsset*> *)photoAssets;
+- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingMedias:(NSArray<PHAsset*> *)assets;
 
 /**
  * @brief Invoked when user press cancel button. The picker does not dismiss itself; the client dismisses it in this callback.

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -389,6 +389,7 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
         PHAsset *asset = fetchResult[indexPath.item-1];
         
         _previewViewController = [[YMSSingleMediaViewController alloc] initWithAsset:asset imageManager:self.imageManager];
+        _previewViewController.view.frame = self.view.frame;
         _previewViewController.view.tintColor = self.theme.tintColor;
         
         if (!_previewTransition) {

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -282,7 +282,8 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 - (void)collectionView:(UICollectionView *)collectionView didDeselectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     if (indexPath.item == 0) {
-        // Camera cell doesn't need to be deselected
+        // The camera cell has no selected/deselected state, so we should present the camera on every touch on the cell
+        [self yms_presentCameraCaptureViewWithDelegate:self];
         return;
     }
     PHFetchResult *fetchResult = self.currentCollectionItem[@"assets"];

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -135,6 +135,11 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
     return [YMSPhotoPickerTheme sharedInstance].statusBarStyle;
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    return [YMSPhotoPickerConfiguration sharedInstance].allowedOrientation;
+}
+
 #pragma mark - Getters
 
 - (YMSPhotoPickerTheme *)theme

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -579,8 +579,6 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 
     NSMutableArray *allAblums = [NSMutableArray array];
 
-    PHFetchResult *smartAlbums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAlbumRegular options:nil];
-
     __block __weak void (^weakFetchAlbums)(PHFetchResult *collections);
     void (^fetchAlbums)(PHFetchResult *collections);
     weakFetchAlbums = fetchAlbums = ^void(PHFetchResult *collections) {
@@ -602,22 +600,18 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
         }
     };
 
+    // Manually choose all the smart albums to show
     PHFetchResult *topLevelUserCollections = [PHCollectionList fetchTopLevelUserCollectionsWithOptions:nil];
-    fetchAlbums(topLevelUserCollections);
-
-    for (PHAssetCollection *collection in smartAlbums) {
-        PHFetchResult *assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:collection options:fetchOptions];
-        if (assetsFetchResult.count > 0) {
-            // put the "all photos" in the first index
-            if (collection.assetCollectionSubtype == PHAssetCollectionSubtypeSmartAlbumUserLibrary) {
-                [allAblums insertObject:@{@"collection": collection
-                                          , @"assets": assetsFetchResult} atIndex:0];
-            }
-            else {
-                [allAblums addObject:@{@"collection": collection
-                                       , @"assets": assetsFetchResult}];
-            }
-        }
+    PHFetchResult *userLibrary = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumUserLibrary options:nil];
+    PHFetchResult *favorites = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumFavorites options:nil];
+    PHFetchResult *videos = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumVideos options:nil];
+    PHFetchResult *screenshots = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumScreenshots options:nil];
+    PHFetchResult *selfPortraits = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumSelfPortraits options:nil];
+    PHFetchResult *albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeAny options:nil];
+    NSArray *collections = @[topLevelUserCollections, userLibrary, favorites, videos, screenshots, selfPortraits, albums];
+    
+    for (PHFetchResult *collection in collections) {
+        fetchAlbums(collection);
     }
     self.collectionItems = [allAblums copy];
 }

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -234,6 +234,7 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     if (indexPath.row == 0) {
+        [self.photoCollectionView deselectItemAtIndexPath:indexPath animated:NO];
         [self yms_presentCameraCaptureViewWithDelegate:self];
     }
     else if (NO == self.allowsMultipleSelection) {
@@ -457,8 +458,6 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
     [picker dismissViewControllerAnimated:YES completion:^(){
-        [self.photoCollectionView deselectItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0] animated:NO];
-
         // Enable camera preview when user allow it first time
         if (![self.session isRunning]) {
             [self.photoCollectionView reloadItemsAtIndexPaths:@[[NSIndexPath indexPathForItem:0 inSection:0]]];

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -601,14 +601,13 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
     };
 
     // Manually choose all the smart albums to show
-    PHFetchResult *topLevelUserCollections = [PHCollectionList fetchTopLevelUserCollectionsWithOptions:nil];
     PHFetchResult *userLibrary = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumUserLibrary options:nil];
     PHFetchResult *favorites = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumFavorites options:nil];
     PHFetchResult *videos = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumVideos options:nil];
     PHFetchResult *screenshots = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumScreenshots options:nil];
     PHFetchResult *selfPortraits = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumSelfPortraits options:nil];
     PHFetchResult *albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeAny options:nil];
-    NSArray *collections = @[topLevelUserCollections, userLibrary, favorites, videos, screenshots, selfPortraits, albums];
+    NSArray *collections = @[userLibrary, favorites, videos, screenshots, selfPortraits, albums];
     
     for (PHFetchResult *collection in collections) {
         fetchAlbums(collection);

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -192,7 +192,7 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 
     [cell.longPressGestureRecognizer addTarget:self action:@selector(presentSinglePhoto:)];
 
-    if ([self.selectedPhotos containsObject:asset]) {
+    if (self.configuration.orderedSelection && [self.selectedPhotos containsObject:asset]) {
         NSUInteger selectionIndex = [self.selectedPhotos indexOfObject:asset];
         cell.selectionOrder = selectionIndex+1;
     }
@@ -219,7 +219,9 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
     if ([cell isKindOfClass:[YMSPhotoCell class]]) {
         YMSPhotoCell *photoCell = (YMSPhotoCell *)cell;
         [photoCell setNeedsAnimateSelection];
-        photoCell.selectionOrder = self.selectedPhotos.count+1;
+        if (self.configuration.orderedSelection) {
+            photoCell.selectionOrder = self.selectedPhotos.count+1;
+        }
     }
     return YES;
 }
@@ -290,13 +292,14 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
     PHFetchResult *fetchResult = self.currentCollectionItem[@"assets"];
     PHAsset *asset = fetchResult[indexPath.item-1];
 
-    NSUInteger removedIndex = [self.selectedPhotos indexOfObject:asset];
-
-    // Reload order higher than removed cell
-    for (NSInteger i=removedIndex+1; i<self.selectedPhotos.count; i++) {
-        PHAsset *needReloadAsset = self.selectedPhotos[i];
-        YMSPhotoCell *cell = (YMSPhotoCell *)[collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:[fetchResult indexOfObject:needReloadAsset]+1 inSection:indexPath.section]];
-        cell.selectionOrder = cell.selectionOrder-1;
+    if (self.configuration.orderedSelection) {
+        NSUInteger removedIndex = [self.selectedPhotos indexOfObject:asset];
+        // Reload order higher than removed cell
+        for (NSInteger i=removedIndex+1; i<self.selectedPhotos.count; i++) {
+            PHAsset *needReloadAsset = self.selectedPhotos[i];
+            YMSPhotoCell *cell = (YMSPhotoCell *)[collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:[fetchResult indexOfObject:needReloadAsset]+1 inSection:indexPath.section]];
+            cell.selectionOrder = cell.selectionOrder-1;
+        }
     }
 
     [self.selectedPhotos removeObject:asset];
@@ -496,8 +499,10 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 
             // Display selection
             [self.photoCollectionView selectItemAtIndexPath:[NSIndexPath indexPathForItem:i+1 inSection:0] animated:NO scrollPosition:UICollectionViewScrollPositionNone];
-            YMSPhotoCell *cell = (YMSPhotoCell *)[self.photoCollectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:i+1 inSection:0]];
-            cell.selectionOrder = [self.selectedPhotos indexOfObject:asset]+1;
+            if (self.configuration.orderedSelection) {
+                YMSPhotoCell *cell = (YMSPhotoCell *)[self.photoCollectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:i+1 inSection:0]];
+                cell.selectionOrder = [self.selectedPhotos indexOfObject:asset]+1;
+            }
 
             selectionNumber--;
             if (selectionNumber == 0) {

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -22,8 +22,6 @@
 static NSString * const YMSCameraCellNibName = @"YMSCameraCell";
 static NSString * const YMSPhotoCellNibName = @"YMSPhotoCell";
 static NSString * const YMSVideoCellNibName = @"YMSVideoCell";
-static const CGFloat YMSNavigationBarMaxTopSpace = 44.0;
-static const CGFloat YMSNavigationBarOriginalTopSpace = 0.0;
 static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 
 @interface YMSPhotoPickerViewController ()<UICollectionViewDataSource, UICollectionViewDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate, PHPhotoLibraryChangeObserver> {
@@ -38,7 +36,6 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 @property (nonatomic, weak) AVCaptureSession *session;
 @property (nonatomic, strong) NSArray *collectionItems;
 @property (nonatomic, strong) NSDictionary *currentCollectionItem;
-@property (nonatomic, weak) IBOutlet NSLayoutConstraint *navigationBarTopLayoutConstraint;
 @property (nonatomic, strong) NSMutableArray *selectedPhotos;
 @property (nonatomic, strong) UIBarButtonItem *doneItem;
 @property (nonatomic, assign) BOOL needToSelectFirstPhoto;
@@ -761,58 +758,6 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
             }];
         }
     });
-}
-
-#pragma mark - UIScrollViewDelegate
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView
-{
-    // Measure table view scolling position is between the expectation
-    if (scrollView.contentOffset.y > YMSNavigationBarOriginalTopSpace
-        && scrollView.contentOffset.y + CGRectGetHeight(scrollView.bounds) < scrollView.contentSize.height - 1) {
-        CGFloat topLayoutConstraintConstant = self.navigationBarTopLayoutConstraint.constant - (scrollView.contentOffset.y - scrollView.lastContentOffset.y);
-
-        // When next top constant is longer than maximum
-        if (topLayoutConstraintConstant < -YMSNavigationBarMaxTopSpace) {
-            self.navigationBarTopLayoutConstraint.constant = -YMSNavigationBarMaxTopSpace;
-        }
-        // When next top constant is smaller than the minimum
-        else if (topLayoutConstraintConstant > YMSNavigationBarOriginalTopSpace) {
-            self.navigationBarTopLayoutConstraint.constant = YMSNavigationBarOriginalTopSpace;
-        }
-        // Adjust navigation bar top space
-        else {
-            self.navigationBarTopLayoutConstraint.constant = topLayoutConstraintConstant;
-        }
-
-        CGFloat navigationBarAlphaStatus = 1.0 - self.navigationBarTopLayoutConstraint.constant/(YMSNavigationBarOriginalTopSpace - YMSNavigationBarMaxTopSpace);
-        self.navigationBar.alpha = navigationBarAlphaStatus;
-    }
-
-    // Measure the scroll direction for adating animation in scrollViewDidEndDragging:
-    [scrollView yms_scrollViewDidScroll];
-}
-
-- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
-{
-    // measure the end point to add animation
-    if (self.navigationBarTopLayoutConstraint.constant > -YMSNavigationBarMaxTopSpace
-        && self.navigationBarTopLayoutConstraint.constant < YMSNavigationBarOriginalTopSpace) {
-
-        [UIView animateWithDuration:0.3 animations:^{
-            if (scrollView.scrollDirection == YMSScrollViewScrollDirectionUp) {
-                self.navigationBarTopLayoutConstraint.constant = -YMSNavigationBarMaxTopSpace;
-            }
-            else if (scrollView.scrollDirection == YMSScrollViewScrollDirectionDown) {
-                self.navigationBarTopLayoutConstraint.constant = YMSNavigationBarOriginalTopSpace;
-            }
-
-            CGFloat navigationBarAlphaStatus = 1.0 - self.navigationBarTopLayoutConstraint.constant/(YMSNavigationBarOriginalTopSpace - YMSNavigationBarMaxTopSpace);
-            self.navigationBar.alpha = navigationBarAlphaStatus;
-
-            [self.view layoutIfNeeded];
-        }];
-    }
 }
 
 @end

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -19,7 +19,6 @@
 
 static NSString * const YMSCameraCellNibName = @"YMSCameraCell";
 static NSString * const YMSPhotoCellNibName = @"YMSPhotoCell";
-static const NSUInteger YMSNumberOfPhotoColumns = 3;
 static const CGFloat YMSNavigationBarMaxTopSpace = 44.0;
 static const CGFloat YMSNavigationBarOriginalTopSpace = 0.0;
 static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
@@ -137,6 +136,11 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
 - (YMSPhotoPickerTheme *)theme
 {
     return [YMSPhotoPickerTheme sharedInstance];
+}
+
+- (YMSPhotoPickerConfiguration *)configuration
+{
+    return [YMSPhotoPickerConfiguration sharedInstance];
 }
 
 #pragma mark - UICollectionViewDataSource
@@ -568,11 +572,12 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
     CGFloat minimumInteritemSpacing = layout.minimumInteritemSpacing;
     UIEdgeInsets sectionInset = layout.sectionInset;
 
-    CGFloat totalInteritemSpacing = MAX((YMSNumberOfPhotoColumns - 1), 0) * minimumInteritemSpacing;
+    NSUInteger numberOfColumns = self.configuration.numberOfColumns;
+    CGFloat totalInteritemSpacing = MAX((numberOfColumns - 1), 0) * minimumInteritemSpacing;
     CGFloat totalHorizontalSpacing = totalInteritemSpacing + sectionInset.left + sectionInset.right;
 
     // Caculate size for portrait mode
-    CGFloat size = (CGFloat)floor((arrangementLength - totalHorizontalSpacing) / YMSNumberOfPhotoColumns);
+    CGFloat size = (CGFloat)floor((arrangementLength - totalHorizontalSpacing) / numberOfColumns);
     self.cellPortraitSize = CGSizeMake(size, size);
 
     // Caculate size for landsacpe mode

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,6 +14,7 @@
             <connections>
                 <outlet property="navigationBar" destination="Hjz-l4-ipX" id="D2j-M2-g4Y"/>
                 <outlet property="navigationBarBackgroundView" destination="QRP-cu-IBQ" id="OjV-S8-cB4"/>
+                <outlet property="navigationBarTopConstraint" destination="wcO-ae-iNw" id="vcP-0V-eqt"/>
                 <outlet property="photoCollectionView" destination="4eg-zN-avL" id="h9q-2l-7iJ"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -41,9 +43,9 @@
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hjz-l4-ipX">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                    <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="64" id="cqm-7K-Unv">
+                        <constraint firstAttribute="height" constant="44" id="cqm-7K-Unv">
                             <variation key="heightClass=compact" constant="32"/>
                         </constraint>
                     </constraints>
@@ -59,16 +61,17 @@
             <constraints>
                 <constraint firstItem="QRP-cu-IBQ" firstAttribute="trailing" secondItem="Hjz-l4-ipX" secondAttribute="trailing" id="60y-QB-Mh5"/>
                 <constraint firstItem="Hjz-l4-ipX" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="CbG-3J-QKQ"/>
-                <constraint firstItem="4eg-zN-avL" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="G1o-kN-h3L"/>
+                <constraint firstItem="4eg-zN-avL" firstAttribute="leading" secondItem="sul-zo-VoP" secondAttribute="leading" id="G1o-kN-h3L"/>
                 <constraint firstAttribute="bottom" secondItem="4eg-zN-avL" secondAttribute="bottom" id="HY4-8g-3cg"/>
-                <constraint firstItem="QRP-cu-IBQ" firstAttribute="top" secondItem="Hjz-l4-ipX" secondAttribute="top" id="JqE-Cg-CJi"/>
+                <constraint firstItem="QRP-cu-IBQ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="JqE-Cg-CJi"/>
                 <constraint firstItem="QRP-cu-IBQ" firstAttribute="bottom" secondItem="Hjz-l4-ipX" secondAttribute="bottom" id="Qg3-GE-X8W"/>
                 <constraint firstAttribute="trailing" secondItem="Hjz-l4-ipX" secondAttribute="trailing" id="TSg-91-hAe"/>
                 <constraint firstItem="4eg-zN-avL" firstAttribute="top" secondItem="Hjz-l4-ipX" secondAttribute="bottom" id="YyS-iM-2Nj"/>
                 <constraint firstItem="QRP-cu-IBQ" firstAttribute="leading" secondItem="Hjz-l4-ipX" secondAttribute="leading" id="feb-Su-kDN"/>
-                <constraint firstAttribute="trailing" secondItem="4eg-zN-avL" secondAttribute="trailing" id="tJj-hI-9JX"/>
-                <constraint firstItem="Hjz-l4-ipX" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="wcO-ae-iNw"/>
+                <constraint firstItem="sul-zo-VoP" firstAttribute="trailing" secondItem="4eg-zN-avL" secondAttribute="trailing" id="tJj-hI-9JX"/>
+                <constraint firstItem="Hjz-l4-ipX" firstAttribute="top" secondItem="sul-zo-VoP" secondAttribute="top" id="wcO-ae-iNw"/>
             </constraints>
+            <viewLayoutGuide key="safeArea" id="sul-zo-VoP"/>
         </view>
     </objects>
 </document>

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
@@ -23,26 +23,26 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="4eg-zN-avL">
-                    <rect key="frame" x="0.0" y="64" width="600" height="536"/>
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="4eg-zN-avL">
+                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="5" minimumInteritemSpacing="5" id="3nw-6W-3Vi">
                         <size key="itemSize" width="50" height="50"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
                         <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                        <inset key="sectionInset" minX="7" minY="7" maxX="7" maxY="0.0"/>
+                        <inset key="sectionInset" minX="5" minY="5" maxX="5" maxY="0.0"/>
                     </collectionViewFlowLayout>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="VBA-eU-e5x"/>
                         <outlet property="delegate" destination="-1" id="vTu-AA-3RI"/>
                     </connections>
                 </collectionView>
-                <view userInteractionEnabled="NO" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QRP-cu-IBQ">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QRP-cu-IBQ">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
-                <navigationBar contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hjz-l4-ipX">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hjz-l4-ipX">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="cqm-7K-Unv">
                             <variation key="heightClass=compact" constant="32"/>

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
@@ -23,7 +23,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="4eg-zN-avL">
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="4eg-zN-avL">
                     <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="5" minimumInteritemSpacing="5" id="3nw-6W-3Vi">

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YMSPhotoPickerViewController">
@@ -16,12 +20,12 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="4eg-zN-avL">
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="4eg-zN-avL">
                     <rect key="frame" x="0.0" y="64" width="600" height="536"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="5" minimumInteritemSpacing="5" id="3nw-6W-3Vi">
                         <size key="itemSize" width="50" height="50"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -33,11 +37,11 @@
                         <outlet property="delegate" destination="-1" id="vTu-AA-3RI"/>
                     </connections>
                 </collectionView>
-                <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QRP-cu-IBQ">
+                <view userInteractionEnabled="NO" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QRP-cu-IBQ">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
-                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hjz-l4-ipX">
+                <navigationBar contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hjz-l4-ipX">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="cqm-7K-Unv">
@@ -45,14 +49,14 @@
                         </constraint>
                     </constraints>
                     <textAttributes key="titleTextAttributes">
-                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </textAttributes>
                     <items>
                         <navigationItem id="k5M-DK-7zB"/>
                     </items>
                 </navigationBar>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="QRP-cu-IBQ" firstAttribute="trailing" secondItem="Hjz-l4-ipX" secondAttribute="trailing" id="60y-QB-Mh5"/>
                 <constraint firstItem="Hjz-l4-ipX" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="CbG-3J-QKQ"/>

--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -13,7 +13,6 @@
             <connections>
                 <outlet property="navigationBar" destination="Hjz-l4-ipX" id="D2j-M2-g4Y"/>
                 <outlet property="navigationBarBackgroundView" destination="QRP-cu-IBQ" id="OjV-S8-cB4"/>
-                <outlet property="navigationBarTopLayoutConstraint" destination="wcO-ae-iNw" id="bBD-Bs-0Lw"/>
                 <outlet property="photoCollectionView" destination="4eg-zN-avL" id="h9q-2l-7iJ"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>

--- a/YangMingShanDemo.xcodeproj/project.pbxproj
+++ b/YangMingShanDemo.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		519140DF1D05571A002B4C5B /* YMSPhotoPickerAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51F2EEE81CEC4D5F006DFC4B /* YMSPhotoPickerAssets.xcassets */; };
 		51F2EEE91CEC4D5F006DFC4B /* YMSPhotoPickerAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51F2EEE81CEC4D5F006DFC4B /* YMSPhotoPickerAssets.xcassets */; };
 		51FF32391D129D020029197B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51FF32291D129D020029197B /* Assets.xcassets */; };
+		8B89087A1FA8967C006CD7F0 /* YMSPlayerPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B081AE1E1D501000137F96 /* YMSPlayerPreviewView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -590,6 +591,7 @@
 				51687A2D1D335D080071643B /* YMSPhotoCell.m in Sources */,
 				51687A261D335D080071643B /* YMSPhotoPickerTheme.m in Sources */,
 				51687A291D335D080071643B /* YMSAlbumPickerViewController.m in Sources */,
+				8B89087A1FA8967C006CD7F0 /* YMSPlayerPreviewView.m in Sources */,
 				51687A271D335D080071643B /* YMSAlbumCell.m in Sources */,
 				01B081A81E1BF28300137F96 /* YMSVideoCell.m in Sources */,
 				511BC61B1D13B33D00738FD4 /* DemoImageViewCell.swift in Sources */,
@@ -738,11 +740,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/YangMingShanDemo/ObjC/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yahoo.YangMingShanDemo;
 				PRODUCT_NAME = YangMingShanDemo;
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -753,11 +758,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/YangMingShanDemo/ObjC/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yahoo.YangMingShanDemo;
 				PRODUCT_NAME = YangMingShanDemo;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -815,11 +822,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/YangMingShanDemo/Swift/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yahoo.YangMingShanDemo;
 				PRODUCT_NAME = YangMingShanDemo;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "YangMingShanDemo/Swift/YangMingShanDemo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
@@ -831,11 +841,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/YangMingShanDemo/Swift/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yahoo.YangMingShanDemo;
 				PRODUCT_NAME = YangMingShanDemo;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "YangMingShanDemo/Swift/YangMingShanDemo-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 			};

--- a/YangMingShanDemo.xcodeproj/project.pbxproj
+++ b/YangMingShanDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		01B081A01E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */; };
+		01B081A71E1BF28300137F96 /* YMSVideoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B081A61E1BF28300137F96 /* YMSVideoCell.m */; };
+		01B081A81E1BF28300137F96 /* YMSVideoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B081A61E1BF28300137F96 /* YMSVideoCell.m */; };
+		01B081AA1E1BF2A000137F96 /* YMSVideoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01B081A91E1BF2A000137F96 /* YMSVideoCell.xib */; };
+		01B081AB1E1BF2A000137F96 /* YMSVideoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01B081A91E1BF2A000137F96 /* YMSVideoCell.xib */; };
+		01B081AC1E1BF2F600137F96 /* YMSPhotoPickerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */; };
+		01B081AF1E1D501000137F96 /* PlayerPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B081AE1E1D501000137F96 /* PlayerPreviewView.m */; };
 		511BC6051D13B27400738FD4 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC6021D13B27400738FD4 /* AppDelegate.m */; };
 		511BC6061D13B27400738FD4 /* DemoListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC6041D13B27400738FD4 /* DemoListViewController.m */; };
 		511BC60F1D13B2C400738FD4 /* DemoImageViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC60C1D13B2C400738FD4 /* DemoImageViewCell.m */; };
@@ -36,8 +42,8 @@
 		513073351D1B8D9000C98705 /* YMSCameraCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 513073271D1B8D9000C98705 /* YMSCameraCell.xib */; };
 		513073361D1B8D9000C98705 /* YMSPhotoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 513073291D1B8D9000C98705 /* YMSPhotoCell.m */; };
 		513073371D1B8D9000C98705 /* YMSPhotoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5130732A1D1B8D9000C98705 /* YMSPhotoCell.xib */; };
-		513073381D1B8D9000C98705 /* YMSSinglePhotoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5130732C1D1B8D9000C98705 /* YMSSinglePhotoViewController.m */; };
-		513073391D1B8D9000C98705 /* YMSSinglePhotoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5130732D1D1B8D9000C98705 /* YMSSinglePhotoViewController.xib */; };
+		513073381D1B8D9000C98705 /* YMSSingleMediaViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5130732C1D1B8D9000C98705 /* YMSSingleMediaViewController.m */; };
+		513073391D1B8D9000C98705 /* YMSSingleMediaViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5130732D1D1B8D9000C98705 /* YMSSingleMediaViewController.xib */; };
 		513073411D1B8DC000C98705 /* UIViewController+YMSPhotoHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5130733B1D1B8DC000C98705 /* UIViewController+YMSPhotoHelper.m */; };
 		513073421D1B8DC000C98705 /* YMSPhotoPickerTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 5130733D1D1B8DC000C98705 /* YMSPhotoPickerTheme.m */; };
 		513073431D1B8DC000C98705 /* YMSPhotoPickerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5130733F1D1B8DC000C98705 /* YMSPhotoPickerViewController.m */; };
@@ -56,8 +62,8 @@
 		51687A2C1D335D080071643B /* YMSCameraCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 513073271D1B8D9000C98705 /* YMSCameraCell.xib */; };
 		51687A2D1D335D080071643B /* YMSPhotoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 513073291D1B8D9000C98705 /* YMSPhotoCell.m */; };
 		51687A2E1D335D080071643B /* YMSPhotoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5130732A1D1B8D9000C98705 /* YMSPhotoCell.xib */; };
-		51687A2F1D335D080071643B /* YMSSinglePhotoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5130732C1D1B8D9000C98705 /* YMSSinglePhotoViewController.m */; };
-		51687A301D335D080071643B /* YMSSinglePhotoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5130732D1D1B8D9000C98705 /* YMSSinglePhotoViewController.xib */; };
+		51687A2F1D335D080071643B /* YMSSingleMediaViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5130732C1D1B8D9000C98705 /* YMSSingleMediaViewController.m */; };
+		51687A301D335D080071643B /* YMSSingleMediaViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5130732D1D1B8D9000C98705 /* YMSSingleMediaViewController.xib */; };
 		519140DF1D05571A002B4C5B /* YMSPhotoPickerAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51F2EEE81CEC4D5F006DFC4B /* YMSPhotoPickerAssets.xcassets */; };
 		51F2EEE91CEC4D5F006DFC4B /* YMSPhotoPickerAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51F2EEE81CEC4D5F006DFC4B /* YMSPhotoPickerAssets.xcassets */; };
 		51FF32391D129D020029197B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51FF32291D129D020029197B /* Assets.xcassets */; };
@@ -83,6 +89,11 @@
 /* Begin PBXFileReference section */
 		01B0819E1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSPhotoPickerConfiguration.h; path = Public/YMSPhotoPickerConfiguration.h; sourceTree = "<group>"; };
 		01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSPhotoPickerConfiguration.m; path = Public/YMSPhotoPickerConfiguration.m; sourceTree = "<group>"; };
+		01B081A51E1BF28300137F96 /* YMSVideoCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSVideoCell.h; path = Private/YMSVideoCell.h; sourceTree = "<group>"; };
+		01B081A61E1BF28300137F96 /* YMSVideoCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSVideoCell.m; path = Private/YMSVideoCell.m; sourceTree = "<group>"; };
+		01B081A91E1BF2A000137F96 /* YMSVideoCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = YMSVideoCell.xib; path = Private/YMSVideoCell.xib; sourceTree = "<group>"; };
+		01B081AD1E1D501000137F96 /* PlayerPreviewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayerPreviewView.h; path = Private/PlayerPreviewView.h; sourceTree = "<group>"; };
+		01B081AE1E1D501000137F96 /* PlayerPreviewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PlayerPreviewView.m; path = Private/PlayerPreviewView.m; sourceTree = "<group>"; };
 		511BC6011D13B27400738FD4 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = ObjC/AppDelegate.h; sourceTree = "<group>"; };
 		511BC6021D13B27400738FD4 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = ObjC/AppDelegate.m; sourceTree = "<group>"; };
 		511BC6031D13B27400738FD4 /* DemoListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DemoListViewController.h; path = ObjC/DemoListViewController.h; sourceTree = "<group>"; };
@@ -123,9 +134,9 @@
 		513073281D1B8D9000C98705 /* YMSPhotoCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSPhotoCell.h; path = YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.h; sourceTree = SOURCE_ROOT; };
 		513073291D1B8D9000C98705 /* YMSPhotoCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSPhotoCell.m; path = YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.m; sourceTree = SOURCE_ROOT; };
 		5130732A1D1B8D9000C98705 /* YMSPhotoCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = YMSPhotoCell.xib; path = YangMingShan/YMSPhotoPicker/Private/YMSPhotoCell.xib; sourceTree = SOURCE_ROOT; };
-		5130732B1D1B8D9000C98705 /* YMSSinglePhotoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSSinglePhotoViewController.h; path = YangMingShan/YMSPhotoPicker/Private/YMSSinglePhotoViewController.h; sourceTree = SOURCE_ROOT; };
-		5130732C1D1B8D9000C98705 /* YMSSinglePhotoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSSinglePhotoViewController.m; path = YangMingShan/YMSPhotoPicker/Private/YMSSinglePhotoViewController.m; sourceTree = SOURCE_ROOT; };
-		5130732D1D1B8D9000C98705 /* YMSSinglePhotoViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = YMSSinglePhotoViewController.xib; path = YangMingShan/YMSPhotoPicker/Private/YMSSinglePhotoViewController.xib; sourceTree = SOURCE_ROOT; };
+		5130732B1D1B8D9000C98705 /* YMSSingleMediaViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSSingleMediaViewController.h; path = YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.h; sourceTree = SOURCE_ROOT; };
+		5130732C1D1B8D9000C98705 /* YMSSingleMediaViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSSingleMediaViewController.m; path = YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.m; sourceTree = SOURCE_ROOT; };
+		5130732D1D1B8D9000C98705 /* YMSSingleMediaViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = YMSSingleMediaViewController.xib; path = YangMingShan/YMSPhotoPicker/Private/YMSSingleMediaViewController.xib; sourceTree = SOURCE_ROOT; };
 		5130733A1D1B8DC000C98705 /* UIViewController+YMSPhotoHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIViewController+YMSPhotoHelper.h"; path = "YangMingShan/YMSPhotoPicker/Public/UIViewController+YMSPhotoHelper.h"; sourceTree = SOURCE_ROOT; };
 		5130733B1D1B8DC000C98705 /* UIViewController+YMSPhotoHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+YMSPhotoHelper.m"; path = "YangMingShan/YMSPhotoPicker/Public/UIViewController+YMSPhotoHelper.m"; sourceTree = SOURCE_ROOT; };
 		5130733C1D1B8DC000C98705 /* YMSPhotoPickerTheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSPhotoPickerTheme.h; path = YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerTheme.h; sourceTree = SOURCE_ROOT; };
@@ -300,9 +311,14 @@
 				513073281D1B8D9000C98705 /* YMSPhotoCell.h */,
 				513073291D1B8D9000C98705 /* YMSPhotoCell.m */,
 				5130732A1D1B8D9000C98705 /* YMSPhotoCell.xib */,
-				5130732B1D1B8D9000C98705 /* YMSSinglePhotoViewController.h */,
-				5130732C1D1B8D9000C98705 /* YMSSinglePhotoViewController.m */,
-				5130732D1D1B8D9000C98705 /* YMSSinglePhotoViewController.xib */,
+				01B081A51E1BF28300137F96 /* YMSVideoCell.h */,
+				01B081A61E1BF28300137F96 /* YMSVideoCell.m */,
+				01B081A91E1BF2A000137F96 /* YMSVideoCell.xib */,
+				5130732B1D1B8D9000C98705 /* YMSSingleMediaViewController.h */,
+				5130732C1D1B8D9000C98705 /* YMSSingleMediaViewController.m */,
+				5130732D1D1B8D9000C98705 /* YMSSingleMediaViewController.xib */,
+				01B081AD1E1D501000137F96 /* PlayerPreviewView.h */,
+				01B081AE1E1D501000137F96 /* PlayerPreviewView.m */,
 			);
 			name = YMSPhotoPicker;
 			path = YangMingShan/YMSPhotoPicker;
@@ -467,9 +483,10 @@
 				513073351D1B8D9000C98705 /* YMSCameraCell.xib in Resources */,
 				513073441D1B8DC000C98705 /* YMSPhotoPickerViewController.xib in Resources */,
 				513073371D1B8D9000C98705 /* YMSPhotoCell.xib in Resources */,
-				513073391D1B8D9000C98705 /* YMSSinglePhotoViewController.xib in Resources */,
+				513073391D1B8D9000C98705 /* YMSSingleMediaViewController.xib in Resources */,
 				513073311D1B8D9000C98705 /* YMSAlbumCell.xib in Resources */,
 				51F2EEE91CEC4D5F006DFC4B /* YMSPhotoPickerAssets.xcassets in Resources */,
+				01B081AA1E1BF2A000137F96 /* YMSVideoCell.xib in Resources */,
 				51FF32391D129D020029197B /* Assets.xcassets in Resources */,
 				5130730D1D13D45800C98705 /* DemoImageViewCell.xib in Resources */,
 			);
@@ -498,10 +515,11 @@
 				51687A2E1D335D080071643B /* YMSPhotoCell.xib in Resources */,
 				513073011D13D03500C98705 /* Main-swift.storyboard in Resources */,
 				519140DF1D05571A002B4C5B /* YMSPhotoPickerAssets.xcassets in Resources */,
-				51687A301D335D080071643B /* YMSSinglePhotoViewController.xib in Resources */,
+				51687A301D335D080071643B /* YMSSingleMediaViewController.xib in Resources */,
 				51687A2C1D335D080071643B /* YMSCameraCell.xib in Resources */,
 				511BC6231D13B3B600738FD4 /* LaunchScreen.storyboard in Resources */,
 				51687A221D335CE80071643B /* YMSPhotoPickerViewController.xib in Resources */,
+				01B081AB1E1BF2A000137F96 /* YMSVideoCell.xib in Resources */,
 				513073101D13D46E00C98705 /* DemoImageViewCell.xib in Resources */,
 				51687A281D335D080071643B /* YMSAlbumCell.xib in Resources */,
 			);
@@ -519,9 +537,11 @@
 				5130732E1D1B8D9000C98705 /* UIScrollView+YMSAdditions.m in Sources */,
 				513073361D1B8D9000C98705 /* YMSPhotoCell.m in Sources */,
 				511BC6051D13B27400738FD4 /* AppDelegate.m in Sources */,
+				01B081A71E1BF28300137F96 /* YMSVideoCell.m in Sources */,
+				01B081AF1E1D501000137F96 /* PlayerPreviewView.m in Sources */,
 				511BC6101D13B2C400738FD4 /* DemoPhotoViewController.m in Sources */,
 				5130732F1D1B8D9000C98705 /* UITableViewCell+YMSConfig.m in Sources */,
-				513073381D1B8D9000C98705 /* YMSSinglePhotoViewController.m in Sources */,
+				513073381D1B8D9000C98705 /* YMSSingleMediaViewController.m in Sources */,
 				511BC6201D13B39E00738FD4 /* main.m in Sources */,
 				513073411D1B8DC000C98705 /* UIViewController+YMSPhotoHelper.m in Sources */,
 				511BC6061D13B27400738FD4 /* DemoListViewController.m in Sources */,
@@ -554,6 +574,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				51687A241D335D080071643B /* UIScrollView+YMSAdditions.m in Sources */,
+				01B081AC1E1BF2F600137F96 /* YMSPhotoPickerConfiguration.m in Sources */,
 				51687A251D335D080071643B /* UITableViewCell+YMSConfig.m in Sources */,
 				51687A211D335CDD0071643B /* YMSPhotoPickerViewController.m in Sources */,
 				511BC6181D13B33D00738FD4 /* AppDelegate.swift in Sources */,
@@ -561,8 +582,9 @@
 				51687A261D335D080071643B /* YMSPhotoPickerTheme.m in Sources */,
 				51687A291D335D080071643B /* YMSAlbumPickerViewController.m in Sources */,
 				51687A271D335D080071643B /* YMSAlbumCell.m in Sources */,
+				01B081A81E1BF28300137F96 /* YMSVideoCell.m in Sources */,
 				511BC61B1D13B33D00738FD4 /* DemoImageViewCell.swift in Sources */,
-				51687A2F1D335D080071643B /* YMSSinglePhotoViewController.m in Sources */,
+				51687A2F1D335D080071643B /* YMSSingleMediaViewController.m in Sources */,
 				51687A2B1D335D080071643B /* YMSCameraCell.m in Sources */,
 				51687A231D335D080071643B /* UIViewController+YMSPhotoHelper.m in Sources */,
 				511BC6191D13B33D00738FD4 /* DemoListViewController.swift in Sources */,

--- a/YangMingShanDemo.xcodeproj/project.pbxproj
+++ b/YangMingShanDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01B081A01E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */; };
 		511BC6051D13B27400738FD4 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC6021D13B27400738FD4 /* AppDelegate.m */; };
 		511BC6061D13B27400738FD4 /* DemoListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC6041D13B27400738FD4 /* DemoListViewController.m */; };
 		511BC60F1D13B2C400738FD4 /* DemoImageViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC60C1D13B2C400738FD4 /* DemoImageViewCell.m */; };
@@ -80,6 +81,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		01B0819E1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSPhotoPickerConfiguration.h; path = Public/YMSPhotoPickerConfiguration.h; sourceTree = "<group>"; };
+		01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSPhotoPickerConfiguration.m; path = Public/YMSPhotoPickerConfiguration.m; sourceTree = "<group>"; };
 		511BC6011D13B27400738FD4 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = ObjC/AppDelegate.h; sourceTree = "<group>"; };
 		511BC6021D13B27400738FD4 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = ObjC/AppDelegate.m; sourceTree = "<group>"; };
 		511BC6031D13B27400738FD4 /* DemoListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DemoListViewController.h; path = ObjC/DemoListViewController.h; sourceTree = "<group>"; };
@@ -280,6 +283,8 @@
 				51FF31EB1D129B4C0029197B /* Categories */,
 				5130733C1D1B8DC000C98705 /* YMSPhotoPickerTheme.h */,
 				5130733D1D1B8DC000C98705 /* YMSPhotoPickerTheme.m */,
+				01B0819E1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.h */,
+				01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */,
 				5130733E1D1B8DC000C98705 /* YMSPhotoPickerViewController.h */,
 				5130733F1D1B8DC000C98705 /* YMSPhotoPickerViewController.m */,
 				513073401D1B8DC000C98705 /* YMSPhotoPickerViewController.xib */,
@@ -510,6 +515,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				511BC60F1D13B2C400738FD4 /* DemoImageViewCell.m in Sources */,
+				01B081A01E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m in Sources */,
 				5130732E1D1B8D9000C98705 /* UIScrollView+YMSAdditions.m in Sources */,
 				513073361D1B8D9000C98705 /* YMSPhotoCell.m in Sources */,
 				511BC6051D13B27400738FD4 /* AppDelegate.m in Sources */,

--- a/YangMingShanDemo.xcodeproj/project.pbxproj
+++ b/YangMingShanDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0101D5171E268E3D00DBA946 /* YMSSingleMediaTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 0101D5161E268E3D00DBA946 /* YMSSingleMediaTransition.m */; };
+		0101D5181E268E3D00DBA946 /* YMSSingleMediaTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 0101D5161E268E3D00DBA946 /* YMSSingleMediaTransition.m */; };
 		01B081A01E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */; };
 		01B081A71E1BF28300137F96 /* YMSVideoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B081A61E1BF28300137F96 /* YMSVideoCell.m */; };
 		01B081A81E1BF28300137F96 /* YMSVideoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B081A61E1BF28300137F96 /* YMSVideoCell.m */; };
@@ -87,6 +89,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0101D5151E268E3D00DBA946 /* YMSSingleMediaTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSSingleMediaTransition.h; path = Private/YMSSingleMediaTransition.h; sourceTree = "<group>"; };
+		0101D5161E268E3D00DBA946 /* YMSSingleMediaTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSSingleMediaTransition.m; path = Private/YMSSingleMediaTransition.m; sourceTree = "<group>"; };
 		01B0819E1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSPhotoPickerConfiguration.h; path = Public/YMSPhotoPickerConfiguration.h; sourceTree = "<group>"; };
 		01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSPhotoPickerConfiguration.m; path = Public/YMSPhotoPickerConfiguration.m; sourceTree = "<group>"; };
 		01B081A51E1BF28300137F96 /* YMSVideoCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSVideoCell.h; path = Private/YMSVideoCell.h; sourceTree = "<group>"; };
@@ -319,6 +323,8 @@
 				5130732D1D1B8D9000C98705 /* YMSSingleMediaViewController.xib */,
 				01B081AD1E1D501000137F96 /* YMSPlayerPreviewView.h */,
 				01B081AE1E1D501000137F96 /* YMSPlayerPreviewView.m */,
+				0101D5151E268E3D00DBA946 /* YMSSingleMediaTransition.h */,
+				0101D5161E268E3D00DBA946 /* YMSSingleMediaTransition.m */,
 			);
 			name = YMSPhotoPicker;
 			path = YangMingShan/YMSPhotoPicker;
@@ -552,6 +558,7 @@
 				513073321D1B8D9000C98705 /* YMSAlbumPickerViewController.m in Sources */,
 				513073341D1B8D9000C98705 /* YMSCameraCell.m in Sources */,
 				513073301D1B8D9000C98705 /* YMSAlbumCell.m in Sources */,
+				0101D5171E268E3D00DBA946 /* YMSSingleMediaTransition.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -587,6 +594,7 @@
 				01B081A81E1BF28300137F96 /* YMSVideoCell.m in Sources */,
 				511BC61B1D13B33D00738FD4 /* DemoImageViewCell.swift in Sources */,
 				51687A2F1D335D080071643B /* YMSSingleMediaViewController.m in Sources */,
+				0101D5181E268E3D00DBA946 /* YMSSingleMediaTransition.m in Sources */,
 				51687A2B1D335D080071643B /* YMSCameraCell.m in Sources */,
 				51687A231D335D080071643B /* UIViewController+YMSPhotoHelper.m in Sources */,
 				511BC6191D13B33D00738FD4 /* DemoListViewController.swift in Sources */,

--- a/YangMingShanDemo.xcodeproj/project.pbxproj
+++ b/YangMingShanDemo.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		01B081AA1E1BF2A000137F96 /* YMSVideoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01B081A91E1BF2A000137F96 /* YMSVideoCell.xib */; };
 		01B081AB1E1BF2A000137F96 /* YMSVideoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01B081A91E1BF2A000137F96 /* YMSVideoCell.xib */; };
 		01B081AC1E1BF2F600137F96 /* YMSPhotoPickerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B0819F1E1BBCA600137F96 /* YMSPhotoPickerConfiguration.m */; };
-		01B081AF1E1D501000137F96 /* PlayerPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B081AE1E1D501000137F96 /* PlayerPreviewView.m */; };
+		01B081AF1E1D501000137F96 /* YMSPlayerPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B081AE1E1D501000137F96 /* YMSPlayerPreviewView.m */; };
 		511BC6051D13B27400738FD4 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC6021D13B27400738FD4 /* AppDelegate.m */; };
 		511BC6061D13B27400738FD4 /* DemoListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC6041D13B27400738FD4 /* DemoListViewController.m */; };
 		511BC60F1D13B2C400738FD4 /* DemoImageViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 511BC60C1D13B2C400738FD4 /* DemoImageViewCell.m */; };
@@ -92,8 +92,8 @@
 		01B081A51E1BF28300137F96 /* YMSVideoCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSVideoCell.h; path = Private/YMSVideoCell.h; sourceTree = "<group>"; };
 		01B081A61E1BF28300137F96 /* YMSVideoCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSVideoCell.m; path = Private/YMSVideoCell.m; sourceTree = "<group>"; };
 		01B081A91E1BF2A000137F96 /* YMSVideoCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = YMSVideoCell.xib; path = Private/YMSVideoCell.xib; sourceTree = "<group>"; };
-		01B081AD1E1D501000137F96 /* PlayerPreviewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayerPreviewView.h; path = Private/PlayerPreviewView.h; sourceTree = "<group>"; };
-		01B081AE1E1D501000137F96 /* PlayerPreviewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PlayerPreviewView.m; path = Private/PlayerPreviewView.m; sourceTree = "<group>"; };
+		01B081AD1E1D501000137F96 /* YMSPlayerPreviewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YMSPlayerPreviewView.h; path = Private/YMSPlayerPreviewView.h; sourceTree = "<group>"; };
+		01B081AE1E1D501000137F96 /* YMSPlayerPreviewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = YMSPlayerPreviewView.m; path = Private/YMSPlayerPreviewView.m; sourceTree = "<group>"; };
 		511BC6011D13B27400738FD4 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = ObjC/AppDelegate.h; sourceTree = "<group>"; };
 		511BC6021D13B27400738FD4 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = ObjC/AppDelegate.m; sourceTree = "<group>"; };
 		511BC6031D13B27400738FD4 /* DemoListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DemoListViewController.h; path = ObjC/DemoListViewController.h; sourceTree = "<group>"; };
@@ -317,8 +317,8 @@
 				5130732B1D1B8D9000C98705 /* YMSSingleMediaViewController.h */,
 				5130732C1D1B8D9000C98705 /* YMSSingleMediaViewController.m */,
 				5130732D1D1B8D9000C98705 /* YMSSingleMediaViewController.xib */,
-				01B081AD1E1D501000137F96 /* PlayerPreviewView.h */,
-				01B081AE1E1D501000137F96 /* PlayerPreviewView.m */,
+				01B081AD1E1D501000137F96 /* YMSPlayerPreviewView.h */,
+				01B081AE1E1D501000137F96 /* YMSPlayerPreviewView.m */,
 			);
 			name = YMSPhotoPicker;
 			path = YangMingShan/YMSPhotoPicker;
@@ -435,6 +435,7 @@
 					5171ACE61CE9A49B00B72748 = {
 						CreatedOnToolsVersion = 7.3;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Manual;
 					};
 					5171ACFF1CE9A49C00B72748 = {
 						CreatedOnToolsVersion = 7.3;
@@ -448,6 +449,7 @@
 					519140CC1D055615002B4C5B = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -538,7 +540,7 @@
 				513073361D1B8D9000C98705 /* YMSPhotoCell.m in Sources */,
 				511BC6051D13B27400738FD4 /* AppDelegate.m in Sources */,
 				01B081A71E1BF28300137F96 /* YMSVideoCell.m in Sources */,
-				01B081AF1E1D501000137F96 /* PlayerPreviewView.m in Sources */,
+				01B081AF1E1D501000137F96 /* YMSPlayerPreviewView.m in Sources */,
 				511BC6101D13B2C400738FD4 /* DemoPhotoViewController.m in Sources */,
 				5130732F1D1B8D9000C98705 /* UITableViewCell+YMSConfig.m in Sources */,
 				513073381D1B8D9000C98705 /* YMSSingleMediaViewController.m in Sources */,
@@ -727,6 +729,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/YangMingShanDemo/ObjC/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yahoo.YangMingShanDemo;
@@ -740,6 +744,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/YangMingShanDemo/ObjC/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yahoo.YangMingShanDemo;
@@ -801,6 +807,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/YangMingShanDemo/Swift/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yahoo.YangMingShanDemo;
@@ -816,6 +823,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/YangMingShanDemo/Swift/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yahoo.YangMingShanDemo;

--- a/YangMingShanDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/YangMingShanDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/YangMingShanDemo/ObjC/Base.lproj/Main.storyboard
+++ b/YangMingShanDemo/ObjC/Base.lproj/Main.storyboard
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="0WR-3P-oxs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0WR-3P-oxs">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--YangMingShan Demo-->
@@ -11,29 +15,29 @@
             <objects>
                 <tableViewController id="bHd-HZ-ms7" customClass="DemoListViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="1Fs-dz-IfO">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="reuseIdentifier" textLabel="drw-X9-c61" detailTextLabel="9l3-6N-lsp" rowHeight="44" style="IBUITableViewCellStyleSubtitle" id="X9z-UB-mYV">
-                                <rect key="frame" x="0.0" y="92" width="600" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="X9z-UB-mYV" id="qQa-R2-VqN">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="drw-X9-c61">
-                                            <rect key="frame" x="15" y="6" width="31.5" height="19.5"/>
+                                            <rect key="frame" x="15" y="5" width="32" height="20"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9l3-6N-lsp">
-                                            <rect key="frame" x="15" y="25.5" width="40.5" height="13.5"/>
+                                            <rect key="frame" x="15" y="25" width="41" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -63,10 +67,10 @@
                         <viewControllerLayoutGuide type="bottom" id="Vcc-P4-QYW"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="PNs-3b-Sgw">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="1" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PvH-IH-gdb">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="1" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PvH-IH-gdb">
                                 <rect key="frame" x="283" y="76" width="38" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="38" id="4WW-As-xvP"/>
@@ -75,18 +79,18 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" keyboardType="numbersAndPunctuation"/>
                             </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Max numbers of photo selections" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KE4-4e-ym0">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Max numbers of photo selections" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KE4-4e-ym0">
                                 <rect key="frame" x="20" y="81" width="255" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="gk1-Ox-f08"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="j0E-RQ-BTS">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" pagingEnabled="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="j0E-RQ-BTS">
                                 <rect key="frame" x="0.0" y="114" width="600" height="486"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="66Z-Gj-KxV">
                                     <size key="itemSize" width="50" height="50"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -100,7 +104,7 @@
                                 </connections>
                             </collectionView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="KE4-4e-ym0" firstAttribute="top" secondItem="XpO-2k-wo4" secondAttribute="bottom" constant="17" id="332-WS-lxY"/>
                             <constraint firstItem="PvH-IH-gdb" firstAttribute="top" secondItem="XpO-2k-wo4" secondAttribute="bottom" constant="12" id="7mc-zS-F2w"/>

--- a/YangMingShanDemo/ObjC/Base.lproj/Main.storyboard
+++ b/YangMingShanDemo/ObjC/Base.lproj/Main.storyboard
@@ -70,7 +70,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="1" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PvH-IH-gdb">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="3" borderStyle="roundedRect" placeholder="1" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PvH-IH-gdb">
                                 <rect key="frame" x="283" y="76" width="38" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="38" id="4WW-As-xvP"/>

--- a/YangMingShanDemo/ObjC/Info.plist
+++ b/YangMingShanDemo/ObjC/Info.plist
@@ -22,6 +22,12 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>The camera is used to take a new photo</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>The microphone is used when taking videos</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>The photo library is used to select photos</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -36,9 +42,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>The photo library is used to select photos</string>
-	<key>NSCameraUsageDescription</key>
-	<string>The camera is used to take a new photo</string>
 </dict>
 </plist>

--- a/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
+++ b/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
@@ -47,6 +47,7 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
         // Custom selection number
         YMSPhotoPickerViewController *pickerViewController = [[YMSPhotoPickerViewController alloc] init];
         pickerViewController.configuration.numberOfColumns = 4;
+        pickerViewController.configuration.sourceType = YMSPhotoPickerSourceTypeBoth;
         pickerViewController.numberOfPhotoToSelect = [numberOfPhotoSelectionString integerValue];
 
         UIColor *customColor = [UIColor colorWithRed:248.0/255.0 green:217.0/255.0 blue:44.0/255.0 alpha:1.0];
@@ -133,6 +134,7 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
         NSMutableArray *mutableImages = [NSMutableArray array];
 
         for (PHAsset *asset in photoAssets) {
+            NSLog(@"%li", (long)asset.mediaType);
             CGSize targetSize = CGSizeMake((CGRectGetWidth(self.collectionView.bounds) - 20*2) * [UIScreen mainScreen].scale, (CGRectGetHeight(self.collectionView.bounds) - 20*2) * [UIScreen mainScreen].scale);
             [imageManager requestImageForAsset:asset targetSize:targetSize contentMode:PHImageContentModeAspectFill options:options resultHandler:^(UIImage *image, NSDictionary *info) {
                 [mutableImages addObject:image];

--- a/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
+++ b/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
@@ -48,6 +48,7 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
         YMSPhotoPickerViewController *pickerViewController = [[YMSPhotoPickerViewController alloc] init];
         pickerViewController.configuration.numberOfColumns = 4;
         pickerViewController.configuration.sourceType = YMSPhotoPickerSourceTypeBoth;
+        pickerViewController.configuration.orderedSelection = NO;
         pickerViewController.numberOfPhotoToSelect = [numberOfPhotoSelectionString integerValue];
 
         UIColor *customColor = [UIColor colorWithRed:248.0/255.0 green:217.0/255.0 blue:44.0/255.0 alpha:1.0];

--- a/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
+++ b/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
@@ -134,7 +134,6 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
         NSMutableArray *mutableImages = [NSMutableArray array];
 
         for (PHAsset *asset in photoAssets) {
-            NSLog(@"%li", (long)asset.mediaType);
             CGSize targetSize = CGSizeMake((CGRectGetWidth(self.collectionView.bounds) - 20*2) * [UIScreen mainScreen].scale, (CGRectGetHeight(self.collectionView.bounds) - 20*2) * [UIScreen mainScreen].scale);
             [imageManager requestImageForAsset:asset targetSize:targetSize contentMode:PHImageContentModeAspectFill options:options resultHandler:^(UIImage *image, NSDictionary *info) {
                 [mutableImages addObject:image];

--- a/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
+++ b/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
@@ -49,6 +49,7 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
         pickerViewController.configuration.numberOfColumns = 4;
         pickerViewController.configuration.sourceType = YMSPhotoPickerSourceTypeBoth;
         pickerViewController.configuration.sortingType = YMSPhotoPickerSortingTypeCreationDescending;
+        pickerViewController.configuration.allowedOrientation = UIInterfaceOrientationMaskPortrait;
         pickerViewController.numberOfMediaToSelect = [numberOfPhotoSelectionString integerValue];
 
         UIColor *customColor = [UIColor colorWithRed:248.0/255.0 green:217.0/255.0 blue:44.0/255.0 alpha:1.0];

--- a/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
+++ b/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
@@ -46,6 +46,7 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
         && [numberOfPhotoSelectionString integerValue] != 1) {
         // Custom selection number
         YMSPhotoPickerViewController *pickerViewController = [[YMSPhotoPickerViewController alloc] init];
+        pickerViewController.configuration.numberOfColumns = 4;
         pickerViewController.numberOfPhotoToSelect = [numberOfPhotoSelectionString integerValue];
 
         UIColor *customColor = [UIColor colorWithRed:248.0/255.0 green:217.0/255.0 blue:44.0/255.0 alpha:1.0];

--- a/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
+++ b/YangMingShanDemo/ObjC/YMSPhotoPickerDemo/DemoPhotoViewController.m
@@ -49,7 +49,7 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
         pickerViewController.configuration.numberOfColumns = 4;
         pickerViewController.configuration.sourceType = YMSPhotoPickerSourceTypeBoth;
         pickerViewController.configuration.orderedSelection = NO;
-        pickerViewController.numberOfPhotoToSelect = [numberOfPhotoSelectionString integerValue];
+        pickerViewController.numberOfMediaToSelect = [numberOfPhotoSelectionString integerValue];
 
         UIColor *customColor = [UIColor colorWithRed:248.0/255.0 green:217.0/255.0 blue:44.0/255.0 alpha:1.0];
 
@@ -112,15 +112,28 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
     [picker presentViewController:alertController animated:YES completion:nil];
 }
 
-- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingImage:(UIImage *)image
+- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingMedia:(PHAsset *)asset
 {
     [picker dismissViewControllerAnimated:YES completion:^() {
-        self.images = @[image];
-        [self.collectionView reloadData];
+        
+        PHImageManager *imageManager = [[PHImageManager alloc] init];
+        
+        PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
+        options.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
+        options.networkAccessAllowed = YES;
+        options.resizeMode = PHImageRequestOptionsResizeModeExact;
+        
+        CGSize targetSize = CGSizeMake(asset.pixelWidth, asset.pixelHeight);
+        
+        [imageManager requestImageForAsset:asset targetSize:targetSize contentMode:PHImageContentModeAspectFill options:options resultHandler:^(UIImage *image, NSDictionary *info) {
+            self.images = @[image];
+            [self.collectionView reloadData];
+        }];
+        
     }];
 }
 
-- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingImages:(NSArray *)photoAssets
+- (void)photoPickerViewController:(YMSPhotoPickerViewController *)picker didFinishPickingMedias:(NSArray *)assets
 {
     [picker dismissViewControllerAnimated:YES completion:^() {
 
@@ -134,7 +147,7 @@ static NSString * const CellIdentifier = @"imageCellIdentifier";
 
         NSMutableArray *mutableImages = [NSMutableArray array];
 
-        for (PHAsset *asset in photoAssets) {
+        for (PHAsset *asset in assets) {
             CGSize targetSize = CGSizeMake((CGRectGetWidth(self.collectionView.bounds) - 20*2) * [UIScreen mainScreen].scale, (CGRectGetHeight(self.collectionView.bounds) - 20*2) * [UIScreen mainScreen].scale);
             [imageManager requestImageForAsset:asset targetSize:targetSize contentMode:PHImageContentModeAspectFill options:options resultHandler:^(UIImage *image, NSDictionary *info) {
                 [mutableImages addObject:image];

--- a/YangMingShanDemo/Swift/Info.plist
+++ b/YangMingShanDemo/Swift/Info.plist
@@ -22,6 +22,12 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>The camera is used to take a new photo</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>The microphone is used when taking videos</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>The photo library is used to select photos</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -36,9 +42,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>The photo library is used to select photos</string>
-	<key>NSCameraUsageDescription</key>
-	<string>The camera is used to take a new photo</string>
 </dict>
 </plist>

--- a/YangMingShanDemo/Swift/YMSPhotoPickerDemo/DemoPhotoViewController.swift
+++ b/YangMingShanDemo/Swift/YMSPhotoPickerDemo/DemoPhotoViewController.swift
@@ -18,8 +18,11 @@ class DemoPhotoViewController: UIViewController, YMSPhotoPickerViewControllerDel
         && UInt(self.numberOfPhotoSelectionTextField.text!) != 1 {
             let pickerViewController = YMSPhotoPickerViewController.init()
 
-            pickerViewController.numberOfPhotoToSelect = UInt(self.numberOfPhotoSelectionTextField.text!)!
-
+            pickerViewController.numberOfMediaToSelect = UInt(self.numberOfPhotoSelectionTextField.text!)!
+            pickerViewController.configuration.numberOfColumns = 3;
+            pickerViewController.configuration.sourceType = .both;
+            pickerViewController.configuration.orderedSelection = false;
+            
             let customColor = UIColor.init(red:248.0/255.0, green:217.0/255.0, blue:44.0/255.0, alpha:1.0)
 
             pickerViewController.theme.titleLabelTextColor = UIColor.black
@@ -83,14 +86,22 @@ class DemoPhotoViewController: UIViewController, YMSPhotoPickerViewControllerDel
         picker.present(alertController, animated: true, completion: nil)
     }
 
-    func photoPickerViewController(_ picker: YMSPhotoPickerViewController!, didFinishPicking image: UIImage!) {
+    func photoPickerViewController(_ picker: YMSPhotoPickerViewController!, didFinishPickingMedia asset: PHAsset!) {
         picker.dismiss(animated: true) {
-            self.images = [image]
-            self.collectionView.reloadData()
+            let imageManager = PHImageManager.init()
+            let options = PHImageRequestOptions.init()
+            options.deliveryMode = .highQualityFormat
+            options.resizeMode = .exact
+            
+            let targetSize = CGSize(width: asset.pixelWidth, height: asset.pixelHeight)
+            imageManager.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: options, resultHandler: { (image, info) in
+                self.images = [image]
+                self.collectionView.reloadData()
+            })
         }
     }
 
-    func photoPickerViewController(_ picker: YMSPhotoPickerViewController!, didFinishPickingImages photoAssets: [PHAsset]!) {
+    func photoPickerViewController(_ picker: YMSPhotoPickerViewController!, didFinishPickingMedias assets: [PHAsset]!) {
 
         picker.dismiss(animated: true) {
             let imageManager = PHImageManager.init()
@@ -101,7 +112,7 @@ class DemoPhotoViewController: UIViewController, YMSPhotoPickerViewControllerDel
 
             let mutableImages: NSMutableArray! = []
 
-            for asset: PHAsset in photoAssets
+            for asset: PHAsset in assets
             {
                 let scale = UIScreen.main.scale
                 let targetSize = CGSize(width: (self.collectionView.bounds.width - 20*2) * scale, height: (self.collectionView.bounds.height - 20*2) * scale)


### PR DESCRIPTION
This makes the component more customizable, by allowing the user to change some options.
These options can be set through a configuration proxy (`YMSPhotoPickerConfiguration`) and are the following:

- `sourceType`: the type of media that can be browsed, captured and selected by the user. This makes `YMSPhotoPicker` compatible with videos.
- `numberOfColumns`: the number of columns of thumbnails visible when browsing the gallery.
- `sortingType`: the way selected medias are sorted in the delegate callback method, and the kind of check displayed on every selected cell (check mark or label of the order).

I don't know if the fact that the component was only compatible with photos was what's intended, but the video compatibility can make it more powerful.
Every part of the lib been adapted (grid cells, preview screen, camera mode and delegate methods).
The default options make the component act just like it is today.